### PR TITLE
fix: update incentives calculation with correct decimal shifts

### DIFF
--- a/packages/math-utils/src/formatters/incentive/calculate-incentive-apy.test.ts
+++ b/packages/math-utils/src/formatters/incentive/calculate-incentive-apy.test.ts
@@ -15,6 +15,7 @@ describe('calculateIncentiveAPY', () => {
         totalTokenSupply: '1000000003465380422',
         tokenPriceInMarketReferenceCurrency: '1634050000000000',
         decimals: 18,
+        rewardTokenDecimals: 18,
       });
 
       expect(result).toEqual('1214271.25215758975164163271');
@@ -27,6 +28,7 @@ describe('calculateIncentiveAPY', () => {
         totalTokenSupply: '145530711359639107416907',
         tokenPriceInMarketReferenceCurrency: '1634050000000000',
         decimals: 18,
+        rewardTokenDecimals: 18,
       });
 
       expect(result).toEqual('0.92708286261063121887');
@@ -39,6 +41,7 @@ describe('calculateIncentiveAPY', () => {
         totalTokenSupply: '43135641118664782764100',
         tokenPriceInMarketReferenceCurrency: '1634050000000000',
         decimals: 18,
+        rewardTokenDecimals: 18,
       });
 
       expect(result).toEqual('0');
@@ -51,6 +54,7 @@ describe('calculateIncentiveAPY', () => {
         totalTokenSupply: '150629528254290021063240208',
         tokenPriceInMarketReferenceCurrency: '1634050000000000',
         decimals: 18,
+        rewardTokenDecimals: 18,
       });
 
       expect(result).toEqual('0.00556406489198376119');
@@ -77,6 +81,7 @@ describe('calculateIncentiveAPY', () => {
         ).toString(),
         tokenPriceInMarketReferenceCurrency: '498035657442060',
         decimals: 18,
+        rewardTokenDecimals: 18,
       });
 
       expect(result).toEqual('0.03490948667901282833');
@@ -89,6 +94,7 @@ describe('calculateIncentiveAPY', () => {
         totalTokenSupply: calculateReserveDebtResult.totalVariableDebt.toFixed(),
         tokenPriceInMarketReferenceCurrency: '498035657442060',
         decimals: 18,
+        rewardTokenDecimals: 18,
       });
 
       expect(result).toEqual('0.02302231808500517936');
@@ -101,6 +107,7 @@ describe('calculateIncentiveAPY', () => {
         totalTokenSupply: calculateReserveDebtResult.totalStableDebt.toFixed(),
         tokenPriceInMarketReferenceCurrency: '498035657442060',
         decimals: 18,
+        rewardTokenDecimals: 18,
       });
 
       expect(result).toEqual('0');
@@ -124,6 +131,7 @@ describe('calculateIncentiveAPY', () => {
         totalTokenSupply: totalLiquidity.toFixed(),
         tokenPriceInMarketReferenceCurrency: '1634050000000000',
         decimals: 18,
+        rewardTokenDecimals: 18,
       });
 
       expect(result).toEqual('0');
@@ -136,6 +144,7 @@ describe('calculateIncentiveAPY', () => {
         totalTokenSupply: calculateReserveDebtResult.totalVariableDebt.toFixed(),
         tokenPriceInMarketReferenceCurrency: '1634050000000000',
         decimals: 18,
+        rewardTokenDecimals: 18,
       });
 
       expect(result).toEqual('0');
@@ -148,6 +157,7 @@ describe('calculateIncentiveAPY', () => {
         totalTokenSupply: calculateReserveDebtResult.totalStableDebt.toFixed(),
         tokenPriceInMarketReferenceCurrency: '1634050000000000',
         decimals: 18,
+        rewardTokenDecimals: 18,
       });
 
       expect(result).toEqual('0');

--- a/packages/math-utils/src/formatters/incentive/calculate-incentive-apy.ts
+++ b/packages/math-utils/src/formatters/incentive/calculate-incentive-apy.ts
@@ -1,12 +1,13 @@
 import { normalize, normalizeBN, valueToBigNumber } from '../../bignumber';
-import { ETH_DECIMALS, SECONDS_PER_YEAR } from '../../constants';
+import { SECONDS_PER_YEAR } from '../../constants';
 
 export interface CalculateIncentiveAPYRequest {
   emissionPerSecond: string;
   rewardTokenPriceInMarketReferenceCurrency: string; // Can be priced in ETH or USD depending on market
   totalTokenSupply: string;
-  decimals: number;
   tokenPriceInMarketReferenceCurrency: string; // Can be priced in ETH or USD depending on market
+  decimals: number;
+  rewardTokenDecimals: number;
 }
 
 // Calculate the APY for an incentive emission
@@ -16,10 +17,11 @@ export function calculateIncentiveAPY({
   tokenPriceInMarketReferenceCurrency,
   totalTokenSupply,
   decimals,
+  rewardTokenDecimals,
 }: CalculateIncentiveAPYRequest): string {
   const emissionPerSecondNormalized = normalizeBN(
     emissionPerSecond,
-    ETH_DECIMALS,
+    rewardTokenDecimals,
   ).multipliedBy(rewardTokenPriceInMarketReferenceCurrency);
 
   if (emissionPerSecondNormalized.eq(0)) {

--- a/packages/math-utils/src/formatters/incentive/calculate-reserve-incentives.test.ts
+++ b/packages/math-utils/src/formatters/incentive/calculate-reserve-incentives.test.ts
@@ -70,4 +70,119 @@ describe('calculateReserveIncentives', () => {
       expect(result.sIncentivesAPY).toBe('0');
     });
   });
+  describe('USDC reserve data from client', () => {
+    it('calculates correct reserve incentives data', () => {
+      const reserveIncentiveUSDC = {
+        underlyingAsset: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
+        aIncentiveData: {
+          emissionPerSecond: '4629629629629629',
+          incentivesLastUpdateTimestamp: '1632883598',
+          tokenIncentivesIndex: '17165951328937142571968723',
+          emissionEndTimestamp: '1637573428',
+          tokenAddress: '0xBcca60bB61934080951369a648Fb03DF4F96263C',
+          rewardTokenAddress: '0x4da27a545c0c5B758a6BA100e3a049001de870f5',
+          incentiveControllerAddress:
+            '0xd784927Ff2f95ba542BfC824c8a8a98F3495f6b5',
+          rewardTokenDecimals: 18,
+          precision: 18,
+        },
+        vIncentiveData: {
+          emissionPerSecond: '4629629629629629',
+          incentivesLastUpdateTimestamp: '1632883598',
+          tokenIncentivesIndex: '22512367540317665709789244',
+          emissionEndTimestamp: '1637573428',
+          tokenAddress: '0x619beb58998eD2278e08620f97007e1116D5D25b',
+          rewardTokenAddress: '0x4da27a545c0c5B758a6BA100e3a049001de870f5',
+          incentiveControllerAddress:
+            '0xd784927Ff2f95ba542BfC824c8a8a98F3495f6b5',
+          rewardTokenDecimals: 18,
+          precision: 18,
+        },
+        sIncentiveData: {
+          emissionPerSecond: '0',
+          incentivesLastUpdateTimestamp: '0',
+          tokenIncentivesIndex: '0',
+          emissionEndTimestamp: '0',
+          tokenAddress: '0x0000000000000000000000000000000000000000',
+          rewardTokenAddress: '0x0000000000000000000000000000000000000000',
+          incentiveControllerAddress:
+            '0x0000000000000000000000000000000000000000',
+          rewardTokenDecimals: 0,
+          precision: 0,
+        },
+      };
+
+      const result = calculateReserveIncentives({
+        reserveIncentiveData: reserveIncentiveUSDC,
+        rewardTokenPriceInMarketReferenceCurrency: '94170917437245430',
+        totalLiquidity: '4689276757732258',
+        liquidityIndex: '1053500517589216842914921776',
+        totalScaledVariableDebt: '3891257648076622',
+        totalPrincipalStableDebt: '41801112749722',
+        tokenPriceInMarketReferenceCurrency: '347780307856538',
+        decimals: 6,
+      });
+
+      expect(result.aIncentivesAPY).toBe('0.00888164801282262266');
+      expect(result.vIncentivesAPY).toBe('0.01015955492045879679');
+      expect(result.sIncentivesAPY).toBe('0');
+    });
+  });
+  describe('DAI reserve data from client', () => {
+    it('calculates correct reserve incentives data', () => {
+      const reserveIncentiveDAI = {
+        underlyingAsset: '0x6B175474E89094C44Da98b954EedeAC495271d0F',
+        aIncentiveData: {
+          emissionPerSecond: '2314814814814814',
+          incentivesLastUpdateTimestamp: '1632885146',
+          tokenIncentivesIndex: '19549435160115',
+          emissionEndTimestamp: '1637573428',
+          tokenAddress: '0x028171bCA77440897B824Ca71D1c56caC55b68A3',
+          rewardTokenAddress: '0x4da27a545c0c5B758a6BA100e3a049001de870f5',
+          incentiveControllerAddress:
+            '0xd784927Ff2f95ba542BfC824c8a8a98F3495f6b5',
+          rewardTokenDecimals: 18,
+          precision: 18,
+        },
+        vIncentiveData: {
+          emissionPerSecond: '2314814814814814',
+          incentivesLastUpdateTimestamp: '1632876638',
+          tokenIncentivesIndex: '26895229234375',
+          emissionEndTimestamp: '1637573428',
+          tokenAddress: '0x6C3c78838c761c6Ac7bE9F59fe808ea2A6E4379d',
+          rewardTokenAddress: '0x4da27a545c0c5B758a6BA100e3a049001de870f5',
+          incentiveControllerAddress:
+            '0xd784927Ff2f95ba542BfC824c8a8a98F3495f6b5',
+          rewardTokenDecimals: 18,
+          precision: 18,
+        },
+        sIncentiveData: {
+          emissionPerSecond: '0',
+          incentivesLastUpdateTimestamp: '0',
+          tokenIncentivesIndex: '0',
+          emissionEndTimestamp: '0',
+          tokenAddress: '0x0000000000000000000000000000000000000000',
+          rewardTokenAddress: '0x0000000000000000000000000000000000000000',
+          incentiveControllerAddress:
+            '0x0000000000000000000000000000000000000000',
+          rewardTokenDecimals: 0,
+          precision: 0,
+        },
+      };
+      const result = calculateReserveIncentives({
+        reserveIncentiveData: reserveIncentiveDAI,
+        rewardTokenPriceInMarketReferenceCurrency: '94170917437245430',
+        totalLiquidity: '1937317748307449835437672174',
+        liquidityIndex: '1053207642011596990084101590',
+        totalScaledVariableDebt: '1440029626743923505023111127',
+        totalPrincipalStableDebt: '9751179387008545009745124',
+        tokenPriceInMarketReferenceCurrency: '350862937422119',
+        decimals: 18,
+      });
+
+      expect(result.aIncentivesAPY).toBe('0.01065161133338641259');
+      expect(result.vIncentivesAPY).toBe('0.01360600854482013582');
+      expect(result.sIncentivesAPY).toBe('0');
+    });
+  });
 });

--- a/packages/math-utils/src/formatters/incentive/calculate-reserve-incentives.ts
+++ b/packages/math-utils/src/formatters/incentive/calculate-reserve-incentives.ts
@@ -47,6 +47,7 @@ export function calculateReserveIncentives({
   liquidityIndex,
   totalScaledVariableDebt,
   totalPrincipalStableDebt,
+  decimals,
   tokenPriceInMarketReferenceCurrency,
 }: CalculateReserveIncentivesRequest): CalculateReserveIncentivesResponse {
   const aIncentivesAPY = calculateIncentiveAPY({
@@ -57,7 +58,9 @@ export function calculateReserveIncentives({
       new BigNumber(totalLiquidity),
       new BigNumber(liquidityIndex),
     ).toString(),
-    decimals: reserveIncentiveData.aIncentiveData.rewardTokenDecimals,
+    decimals,
+    rewardTokenDecimals:
+      reserveIncentiveData.aIncentiveData.rewardTokenDecimals,
   });
 
   const vIncentivesAPY = calculateIncentiveAPY({
@@ -65,7 +68,9 @@ export function calculateReserveIncentives({
     rewardTokenPriceInMarketReferenceCurrency,
     tokenPriceInMarketReferenceCurrency,
     totalTokenSupply: totalScaledVariableDebt,
-    decimals: reserveIncentiveData.vIncentiveData.rewardTokenDecimals,
+    decimals,
+    rewardTokenDecimals:
+      reserveIncentiveData.aIncentiveData.rewardTokenDecimals,
   });
 
   const sIncentivesAPY = calculateIncentiveAPY({
@@ -73,7 +78,9 @@ export function calculateReserveIncentives({
     rewardTokenPriceInMarketReferenceCurrency,
     tokenPriceInMarketReferenceCurrency,
     totalTokenSupply: totalPrincipalStableDebt,
-    decimals: reserveIncentiveData.sIncentiveData.rewardTokenDecimals,
+    decimals,
+    rewardTokenDecimals:
+      reserveIncentiveData.aIncentiveData.rewardTokenDecimals,
   });
 
   return {


### PR DESCRIPTION
APYs were showing up with incorrect decimal places for assets with < 18 decimals. Updated the function to properly use reserve and rewardToken decimals.