### PR TITLE
fix: drop ipfs fetching

### DIFF
--- a/packages/contract-helpers/src/commons/ipfs.ts
+++ b/packages/contract-helpers/src/commons/ipfs.ts
@@ -28,11 +28,7 @@ export async function getProposalMetadata(
     : hash;
   if (MEMORIZE[ipfsHash]) return MEMORIZE[ipfsHash];
   try {
-    const ipfsResponse: Response = await fetch(getLink(ipfsHash, gateway), {
-      headers: {
-        'Content-Type': 'application/json',
-      },
-    });
+    const ipfsResponse: Response = await fetch(getLink(ipfsHash, gateway));
     if (!ipfsResponse.ok) {
       throw Error('Fetch not working');
     }


### PR DESCRIPTION
Setting custom content headers, will lead to a preflight OPTIONS check, which is not allowed by some ipfs gateways which will result in a cors error. Therefore this pr aims to remove the headers.