### PR TITLE
fix: peer dependency versions

### DIFF
--- a/packages/contract-helpers/package.json
+++ b/packages/contract-helpers/package.json
@@ -15,7 +15,8 @@
     "prepublishOnly": "yarn build"
   },
   "peerDependencies": {
-    "ethers": "^5.4.7"
+    "ethers": "5.x",
+    "reflect-metadata": "0.1.x"
   },
   "devDependencies": {
     "ethers": "5.4.7",


### PR DESCRIPTION
Loosen `ethers` version dependency and add `reflect-metadata` to peerDependencies