### PR TITLE
fix: update paraswap calldata mapping (#295)

### DIFF
--- a/packages/contract-helpers/package.json
+++ b/packages/contract-helpers/package.json
@@ -15,7 +15,7 @@
     "prepublishOnly": "yarn build"
   },
   "peerDependencies": {
-    "ethers": "~5.4.7"
+    "ethers": "5.x"
   },
   "devDependencies": {
     "ethers": "5.4.7",

--- a/packages/contract-helpers/src/paraswap-liquiditySwapAdapter-contract/index.ts
+++ b/packages/contract-helpers/src/paraswap-liquiditySwapAdapter-contract/index.ts
@@ -32,6 +32,8 @@ export function augustusFromAmountOffsetFromCalldata(calldata: string): number {
       return 4; // 4 + 0 * 32
     case '0xf5661034': // Augustus V5 swapOnUniswapFork
       return 68; // 4 + 2 * 32
+    case '0x0b86a4c1': // Augustus V5 swapOnUniswapV2Fork
+      return 36; // 4 + 1 * 32
     case '0x64466805': // Augustus V5 swapOnZeroXv4
       return 68; // 4 + 2 * 32
     case '0xa94e78ef': // Augustus V5 multiSwap

--- a/packages/contract-helpers/src/paraswap-liquiditySwapAdapter-contract/paraswapLiquiditySwapAdapter.test.ts
+++ b/packages/contract-helpers/src/paraswap-liquiditySwapAdapter-contract/paraswapLiquiditySwapAdapter.test.ts
@@ -82,6 +82,12 @@ describe('LiquiditySwapAdapterService', () => {
 
       expect(offset).toEqual(68);
     });
+    it('Expects 36 when Augustus V5 swapOnUniswapV2Fork', () => {
+      const callData = '0x0b86a4c10000000000otherCallData000000000';
+      const offset = augustusFromAmountOffsetFromCalldata(callData);
+
+      expect(offset).toEqual(36);
+    });
     it('Expects 68 when Augustus V5 swapOnZeroXv4', () => {
       const callData = '0x644668050000000000otherCallData000000000';
       const offset = augustusFromAmountOffsetFromCalldata(callData);


### PR DESCRIPTION
* fix: test release

* fix: loosen ethers

* Update packages/contract-helpers/src/paraswap-liquiditySwapAdapter-contract/paraswapLiquiditySwapAdapter.test.ts