### PR TITLE
fix(package): url defect in manifest

### DIFF
--- a/packages/contract-helpers/package.json
+++ b/packages/contract-helpers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aave/contract-helpers",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "license": "MIT",
   "description": "",
   "scripts": {
@@ -27,13 +27,13 @@
   "types": "./dist/esm/index.d.ts",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/@aave/aave-utilities.git"
+    "url": "git+https://github.com/aave/aave-utilities.git"
   },
   "author": "",
   "bugs": {
-    "url": "https://github.com/@aave/aave-utilities/issues"
+    "url": "https://github.com/aave/aave-utilities/issues"
   },
-  "homepage": "https://github.com/@aave/aave-utilities#readme",
+  "homepage": "https://github.com/aave/aave-utilities#readme",
   "gitHead": "47a9a6d1f940185ab1e7f6c2bea61564b2abe47a",
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
corrects a malformed URL entries in the package manifest

currently , the URL on npm goes to this: https://github.com/%40aave/aave-utilities

![](https://d.pr/i/bOdGwM.jpeg)