### PR TITLE
Added option to skip gas estimation in order to support transaction batching

### DIFF
--- a/packages/contract-helpers/src/commons/BaseService.test.ts
+++ b/packages/contract-helpers/src/commons/BaseService.test.ts
@@ -101,6 +101,17 @@ describe('BaseService', () => {
       expect(tx.value).toEqual(DEFAULT_NULL_VALUE_ON_TX);
       expect(tx.gasLimit).toEqual(BigNumber.from(300000));
     });
+    it('Expects transaction gasLimit to be 1 when skipping gas estimation', async () => {
+      const txCallback = baseService.generateTxCallback({
+        rawTxMethod,
+        from,
+        value,
+        gasSurplus,
+      });
+
+      const tx = await txCallback(true);
+      expect(tx.gasLimit).toEqual(BigNumber.from(1));
+    });
   });
   describe('generateTxPriceEstimation', () => {
     const baseService = new BaseService(provider, Test__factory);

--- a/packages/contract-helpers/src/commons/BaseService.ts
+++ b/packages/contract-helpers/src/commons/BaseService.ts
@@ -53,8 +53,10 @@ export default class BaseService<T extends Contract> {
       value,
       gasSurplus,
       action,
-    }: TransactionGenerationMethod): (() => Promise<transactionType>) =>
-    async () => {
+    }: TransactionGenerationMethod): ((
+      skipGasEstimation?: boolean,
+    ) => Promise<transactionType>) =>
+    async (skipGasEstimation = false) => {
       const txRaw: PopulatedTransaction = await rawTxMethod();
 
       const tx: transactionType = {
@@ -63,7 +65,9 @@ export default class BaseService<T extends Contract> {
         value: value ?? DEFAULT_NULL_VALUE_ON_TX,
       };
 
-      tx.gasLimit = await estimateGasByNetwork(tx, this.provider, gasSurplus);
+      tx.gasLimit = skipGasEstimation
+        ? BigNumber.from(1)
+        : await estimateGasByNetwork(tx, this.provider, gasSurplus);
 
       if (
         action &&

--- a/packages/contract-helpers/src/commons/types.ts
+++ b/packages/contract-helpers/src/commons/types.ts
@@ -203,7 +203,7 @@ export type ContractAddresses = Record<string, tEthereumAddress>;
 
 export type EthereumTransactionTypeExtended = {
   txType: eEthereumTxType;
-  tx: () => Promise<transactionType>;
+  tx: (skipGasEstimation?: boolean) => Promise<transactionType>;
   gas: GasResponse;
 };
 


### PR DESCRIPTION
This PR implements a possibility of skipping the gas estimation for the func returned by generateTxCallback.

This is required for transaction batching, and also useful to skip overhead, in case of smart wallets that process their own gas estimation

this PR goes in pair with the PR of aave/interface [LINK] , that implements transaction batching (Approval + Transaction) at the same time

Please advise if there's a better way