### PR TITLE
Fix/reward distribution end

### DIFF
--- a/packages/math-utils/src/formatters/incentive/calculate-all-reserve-incentives.test.ts
+++ b/packages/math-utils/src/formatters/incentive/calculate-all-reserve-incentives.test.ts
@@ -38,6 +38,30 @@ describe('calculateAllReserveIncentives', () => {
     ).toBe('0');
   });
 
+  it('calculate incentives for reserve with distribution ended', () => {
+    const rewardDistributionEnd = reserveIncentiveMock.reserveIncentive;
+    rewardDistributionEnd.aIncentiveData.rewardsTokenInformation[0].emissionEndTimestamp = 1;
+    rewardDistributionEnd.vIncentiveData.rewardsTokenInformation[0].emissionEndTimestamp = 1;
+    rewardDistributionEnd.sIncentiveData.rewardsTokenInformation[0].emissionEndTimestamp = 1;
+    const result = calculateAllReserveIncentives({
+      reserveIncentives: [reserveIncentiveMock.reserveIncentive],
+      reserves: [reserve],
+      marketReferenceCurrencyDecimals: 8,
+    });
+    expect(
+      result['0x0000000000000000000000000000000000000000'].aIncentives[0]
+        .incentiveAPR,
+    ).toBe('0');
+    expect(
+      result['0x0000000000000000000000000000000000000000'].vIncentives[0]
+        .incentiveAPR,
+    ).toBe('0');
+    expect(
+      result['0x0000000000000000000000000000000000000000'].sIncentives[0]
+        .incentiveAPR,
+    ).toBe('0');
+  });
+
   it('not add reserveIncentivesDict entry if no reserve is found', () => {
     const result = calculateAllReserveIncentives({
       reserveIncentives: [reserveIncentiveMock.reserveIncentive],

--- a/packages/math-utils/src/formatters/incentive/calculate-reserve-incentives.ts
+++ b/packages/math-utils/src/formatters/incentive/calculate-reserve-incentives.ts
@@ -1,6 +1,6 @@
 import { normalize } from '../../bignumber';
 import { calculateIncentiveAPR } from './calculate-incentive-apr';
-import { ReservesIncentiveDataHumanized } from './types';
+import { ReservesIncentiveDataHumanized, RewardInfoHumanized } from './types';
 
 export interface CalculateReserveIncentivesRequest {
   reserves: Array<{
@@ -59,6 +59,15 @@ export function calculateRewardTokenPrice(
   return '0';
 }
 
+// Determine is reward emsission is active or distribution has ended
+const rewardEmissionActive = (reward: RewardInfoHumanized) => {
+  if (reward.emissionEndTimestamp > reward.incentivesLastUpdateTimestamp) {
+    return true;
+  }
+
+  return false;
+};
+
 // Calculate supply, variableBorrow, and stableBorrow incentives APR for a reserve asset
 export function calculateReserveIncentives({
   reserves,
@@ -71,19 +80,22 @@ export function calculateReserveIncentives({
 }: CalculateReserveIncentivesRequest): CalculateReserveIncentivesResponse {
   const aIncentivesData: ReserveIncentiveResponse[] =
     reserveIncentiveData.aIncentiveData.rewardsTokenInformation.map(reward => {
-      const aIncentivesAPR = calculateIncentiveAPR({
-        emissionPerSecond: reward.emissionPerSecond,
-        rewardTokenPriceInMarketReferenceCurrency: calculateRewardTokenPrice(
-          reserves,
-          reward.rewardTokenAddress,
-          reward.rewardPriceFeed,
-          reward.priceFeedDecimals,
-        ),
-        priceInMarketReferenceCurrency,
-        totalTokenSupply: totalLiquidity,
-        decimals,
-        rewardTokenDecimals: reward.rewardTokenDecimals,
-      });
+      const aIncentivesAPR = rewardEmissionActive(reward)
+        ? calculateIncentiveAPR({
+            emissionPerSecond: reward.emissionPerSecond,
+            rewardTokenPriceInMarketReferenceCurrency:
+              calculateRewardTokenPrice(
+                reserves,
+                reward.rewardTokenAddress,
+                reward.rewardPriceFeed,
+                reward.priceFeedDecimals,
+              ),
+            priceInMarketReferenceCurrency,
+            totalTokenSupply: totalLiquidity,
+            decimals,
+            rewardTokenDecimals: reward.rewardTokenDecimals,
+          })
+        : '0';
       const aIncentiveData: ReserveIncentiveResponse = {
         incentiveAPR: aIncentivesAPR,
         rewardTokenAddress: reward.rewardTokenAddress,
@@ -93,19 +105,22 @@ export function calculateReserveIncentives({
     });
   const vIncentivesData: ReserveIncentiveResponse[] =
     reserveIncentiveData.vIncentiveData.rewardsTokenInformation.map(reward => {
-      const vIncentivesAPR = calculateIncentiveAPR({
-        emissionPerSecond: reward.emissionPerSecond,
-        rewardTokenPriceInMarketReferenceCurrency: calculateRewardTokenPrice(
-          reserves,
-          reward.rewardTokenAddress,
-          reward.rewardPriceFeed,
-          reward.priceFeedDecimals,
-        ),
-        priceInMarketReferenceCurrency,
-        totalTokenSupply: totalVariableDebt,
-        decimals,
-        rewardTokenDecimals: reward.rewardTokenDecimals,
-      });
+      const vIncentivesAPR = rewardEmissionActive(reward)
+        ? calculateIncentiveAPR({
+            emissionPerSecond: reward.emissionPerSecond,
+            rewardTokenPriceInMarketReferenceCurrency:
+              calculateRewardTokenPrice(
+                reserves,
+                reward.rewardTokenAddress,
+                reward.rewardPriceFeed,
+                reward.priceFeedDecimals,
+              ),
+            priceInMarketReferenceCurrency,
+            totalTokenSupply: totalVariableDebt,
+            decimals,
+            rewardTokenDecimals: reward.rewardTokenDecimals,
+          })
+        : '0';
       const vIncentiveData: ReserveIncentiveResponse = {
         incentiveAPR: vIncentivesAPR,
         rewardTokenAddress: reward.rewardTokenAddress,
@@ -115,19 +130,22 @@ export function calculateReserveIncentives({
     });
   const sIncentivesData: ReserveIncentiveResponse[] =
     reserveIncentiveData.sIncentiveData.rewardsTokenInformation.map(reward => {
-      const sIncentivesAPR = calculateIncentiveAPR({
-        emissionPerSecond: reward.emissionPerSecond,
-        rewardTokenPriceInMarketReferenceCurrency: calculateRewardTokenPrice(
-          reserves,
-          reward.rewardTokenAddress,
-          reward.rewardPriceFeed,
-          reward.priceFeedDecimals,
-        ),
-        priceInMarketReferenceCurrency,
-        totalTokenSupply: totalStableDebt,
-        decimals,
-        rewardTokenDecimals: reward.rewardTokenDecimals,
-      });
+      const sIncentivesAPR = rewardEmissionActive(reward)
+        ? calculateIncentiveAPR({
+            emissionPerSecond: reward.emissionPerSecond,
+            rewardTokenPriceInMarketReferenceCurrency:
+              calculateRewardTokenPrice(
+                reserves,
+                reward.rewardTokenAddress,
+                reward.rewardPriceFeed,
+                reward.priceFeedDecimals,
+              ),
+            priceInMarketReferenceCurrency,
+            totalTokenSupply: totalStableDebt,
+            decimals,
+            rewardTokenDecimals: reward.rewardTokenDecimals,
+          })
+        : '0';
       const sIncentiveData: ReserveIncentiveResponse = {
         incentiveAPR: sIncentivesAPR,
         rewardTokenAddress: reward.rewardTokenAddress,

--- a/packages/math-utils/src/formatters/reserve/index.ts
+++ b/packages/math-utils/src/formatters/reserve/index.ts
@@ -303,6 +303,7 @@ export interface FormatReserveUSDResponse extends FormatReserveResponse {
   totalStableDebtUSD: string;
   borrowCapUSD: string;
   supplyCapUSD: string;
+  unbackedUSD: string;
   priceInMarketReferenceCurrency: string;
   formattedPriceInMarketReferenceCurrency: string;
   priceInUSD: string;
@@ -396,6 +397,11 @@ export function formatReserveUSD({
     ).toString(),
     supplyCapUSD: normalizedToUsd(
       new BigNumber(reserve.supplyCap),
+      marketReferencePriceInUsd,
+      marketReferenceCurrencyDecimals,
+    ).toString(),
+    unbackedUSD: normalizedToUsd(
+      new BigNumber(reserve.unbacked),
       marketReferencePriceInUsd,
       marketReferenceCurrencyDecimals,
     ).toString(),

--- a/packages/math-utils/src/mocks.ts
+++ b/packages/math-utils/src/mocks.ts
@@ -132,6 +132,7 @@ export class UserReserveMock {
       totalStableDebtUSD: '0',
       borrowCapUSD: '0',
       supplyCapUSD: '0',
+      unbackedUSD: '0',
       priceInMarketReferenceCurrency: (10 ** 19).toString(),
       formattedPriceInMarketReferenceCurrency: '10',
       unborrowedLiquidity: '0',

--- a/packages/math-utils/src/mocks.ts
+++ b/packages/math-utils/src/mocks.ts
@@ -208,7 +208,7 @@ export class ReserveIncentiveMock {
             emissionPerSecond: (10 ** 18).toString(), // 1
             incentivesLastUpdateTimestamp: 1,
             tokenIncentivesIndex: RAY.toString(),
-            emissionEndTimestamp: 1,
+            emissionEndTimestamp: 2,
             rewardTokenAddress: '0x0000000000000000000000000000000000000000',
             rewardTokenDecimals: 18,
             precision: 18,
@@ -228,7 +228,7 @@ export class ReserveIncentiveMock {
             emissionPerSecond: (10 ** 18).toString(), // 1
             incentivesLastUpdateTimestamp: 1,
             tokenIncentivesIndex: RAY.toString(),
-            emissionEndTimestamp: 1,
+            emissionEndTimestamp: 2,
             rewardTokenAddress: '0x0000000000000000000000000000000000000000',
             rewardTokenDecimals: 18,
             precision: 18,
@@ -248,7 +248,7 @@ export class ReserveIncentiveMock {
             emissionPerSecond: '0',
             incentivesLastUpdateTimestamp: 1,
             tokenIncentivesIndex: '0',
-            emissionEndTimestamp: 1,
+            emissionEndTimestamp: 2,
             rewardTokenAddress: '0x0000000000000000000000000000000000000000',
             rewardTokenDecimals: 18,
             precision: 18,


### PR DESCRIPTION
For v2 incentives, the emissionPerSecond is not updated to 0 if emissionEndTimestamp > currentTimestamp. This factors in the emissionEndTimestamp to the APR calculation.