### PR TITLE
fix: revert switch to simple flashloan

### DIFF
--- a/packages/contract-helpers/src/v3-pool-contract/index.ts
+++ b/packages/contract-helpers/src/v3-pool-contract/index.ts
@@ -1414,10 +1414,12 @@ export class Pool extends BaseService<IPool> implements PoolInterface {
 
     const txCallback: () => Promise<transactionType> = this.generateTxCallback({
       rawTxMethod: async () =>
-        poolContract.populateTransaction.flashLoanSimple(
+        poolContract.populateTransaction.flashLoan(
           this.flashLiquidationAddress,
-          borrowedAsset,
-          flashBorrowAmount,
+          [borrowedAsset],
+          [flashBorrowAmount],
+          [0],
+          initiator,
           params,
           '0',
         ),

--- a/packages/contract-helpers/src/v3-pool-contract/index.ts
+++ b/packages/contract-helpers/src/v3-pool-contract/index.ts
@@ -1057,6 +1057,7 @@ export class Pool extends BaseService<IPool> implements PoolInterface {
     @isEthAddress('fromAsset')
     @isEthAddress('fromAToken')
     @isEthAddress('toAsset')
+    @isEthAddress('onBehalfOf')
     @isEthAddress('augustus')
     @isPositiveAmount('fromAmount')
     @isPositiveAmount('minToAmount')
@@ -1070,6 +1071,7 @@ export class Pool extends BaseService<IPool> implements PoolInterface {
       minToAmount,
       permitSignature,
       swapAll,
+      onBehalfOf,
       referralCode,
       augustus,
       swapCallData,
@@ -1146,10 +1148,12 @@ export class Pool extends BaseService<IPool> implements PoolInterface {
       const txCallback: () => Promise<transactionType> =
         this.generateTxCallback({
           rawTxMethod: async () =>
-            poolContract.populateTransaction.flashLoanSimple(
+            poolContract.populateTransaction.flashLoan(
               this.swapCollateralAddress,
-              fromAsset,
-              swapAll ? convertedAmountWithSurplus : convertedAmount,
+              [fromAsset],
+              swapAll ? [convertedAmountWithSurplus] : [convertedAmount],
+              [0], // interest rate mode to NONE for flashloan to not open debt
+              onBehalfOf ?? user,
               params,
               referralCode ?? '0',
             ),
@@ -1195,6 +1199,7 @@ export class Pool extends BaseService<IPool> implements PoolInterface {
     @isEthAddress('fromAsset')
     @isEthAddress('fromAToken')
     @isEthAddress('assetToRepay')
+    @isEthAddress('onBehalfOf')
     @isPositiveAmount('repayWithAmount')
     @isPositiveAmount('repayAmount')
     @isEthAddress('augustus')
@@ -1208,6 +1213,7 @@ export class Pool extends BaseService<IPool> implements PoolInterface {
       permitSignature,
       repayAllDebt,
       rateMode,
+      onBehalfOf,
       referralCode,
       flash,
       swapAndRepayCallData,
@@ -1304,12 +1310,14 @@ export class Pool extends BaseService<IPool> implements PoolInterface {
       const txCallback: () => Promise<transactionType> =
         this.generateTxCallback({
           rawTxMethod: async () =>
-            poolContract.populateTransaction.flashLoanSimple(
+            poolContract.populateTransaction.flashLoan(
               this.repayWithCollateralAddress,
-              fromAsset,
+              [fromAsset],
               repayAllDebt
-                ? convertedRepayWithAmountWithSurplus
-                : convertedRepayWithAmount,
+                ? [convertedRepayWithAmountWithSurplus]
+                : [convertedRepayWithAmount],
+              [0], // interest rate mode to NONE for flashloan to not open debt
+              onBehalfOf ?? user,
               params,
               referralCode ?? '0',
             ),

--- a/packages/contract-helpers/src/v3-pool-contract/lendingPoolTypes.ts
+++ b/packages/contract-helpers/src/v3-pool-contract/lendingPoolTypes.ts
@@ -78,6 +78,7 @@ export type LPSwapCollateral = {
   minToAmount: string;
   permitSignature?: PermitSignature;
   swapAll: boolean;
+  onBehalfOf?: tEthereumAddress;
   referralCode?: string;
   augustus: tEthereumAddress;
   swapCallData: BytesLike;
@@ -93,6 +94,7 @@ export type LPParaswapRepayWithCollateral = {
   permitSignature?: PermitSignature;
   repayAllDebt?: boolean;
   rateMode: InterestRate;
+  onBehalfOf?: tEthereumAddress;
   referralCode?: string;
   flash?: boolean;
   swapAndRepayCallData: BytesLike;

--- a/packages/contract-helpers/src/v3-pool-contract/pool.test.ts
+++ b/packages/contract-helpers/src/v3-pool-contract/pool.test.ts
@@ -3207,6 +3207,7 @@ describe('Pool', () => {
     const fromAsset = '0x0000000000000000000000000000000000000007';
     const fromAToken = '0x0000000000000000000000000000000000000008';
     const toAsset = '0x0000000000000000000000000000000000000009';
+    const onBehalfOf = '0x0000000000000000000000000000000000000010';
     const augustus = '0x0000000000000000000000000000000000000011';
     const fromAmount = '12.34';
     const minToAmount = '13.56';
@@ -3262,6 +3263,7 @@ describe('Pool', () => {
         minToAmount,
         permitSignature,
         swapAll,
+        onBehalfOf,
         referralCode,
         augustus,
         swapCallData,
@@ -3282,7 +3284,15 @@ describe('Pool', () => {
       expect(tx.value).toEqual(DEFAULT_NULL_VALUE_ON_TX);
 
       const decoded = utils.defaultAbiCoder.decode(
-        ['address', 'address', 'uint256', 'bytes', 'uint16'],
+        [
+          'address',
+          'address[]',
+          'uint256[]',
+          'uint256[]',
+          'address',
+          'bytes',
+          'uint16',
+        ],
         utils.hexDataSlice(tx.data ?? '', 4),
       );
 
@@ -3312,12 +3322,14 @@ describe('Pool', () => {
       );
 
       expect(decoded[0]).toEqual(SWAP_COLLATERAL_ADAPTER);
-      expect(decoded[1]).toEqual(fromAsset);
-      expect(decoded[2]).toEqual(
+      expect(decoded[1]).toEqual([fromAsset]);
+      expect(decoded[2]).toEqual([
         BigNumber.from(valueToWei(amountWithSurplus, decimals)),
-      );
-      expect(decoded[3]).toEqual(params);
-      expect(decoded[4]).toEqual(Number(referralCode));
+      ]);
+      expect(decoded[3]).toEqual([BigNumber.from(0)]);
+      expect(decoded[4]).toEqual(onBehalfOf);
+      expect(decoded[5]).toEqual(params);
+      expect(decoded[6]).toEqual(Number(referralCode));
 
       // gas price
       const gasPrice: GasType | null = await txObj.gas();
@@ -3366,7 +3378,15 @@ describe('Pool', () => {
       expect(tx.value).toEqual(DEFAULT_NULL_VALUE_ON_TX);
 
       const decoded = utils.defaultAbiCoder.decode(
-        ['address', 'address', 'uint256', 'bytes', 'uint16'],
+        [
+          'address',
+          'address[]',
+          'uint256[]',
+          'uint256[]',
+          'address',
+          'bytes',
+          'uint16',
+        ],
         utils.hexDataSlice(tx.data ?? '', 4),
       );
 
@@ -3396,12 +3416,14 @@ describe('Pool', () => {
       );
 
       expect(decoded[0]).toEqual(SWAP_COLLATERAL_ADAPTER);
-      expect(decoded[1]).toEqual(fromAsset);
-      expect(decoded[2]).toEqual(
+      expect(decoded[1]).toEqual([fromAsset]);
+      expect(decoded[2]).toEqual([
         BigNumber.from(valueToWei(amountWithSurplus, decimals)),
-      );
-      expect(decoded[3]).toEqual(params);
-      expect(decoded[4]).toEqual(Number(referralCode));
+      ]);
+      expect(decoded[3]).toEqual([BigNumber.from(0)]);
+      expect(decoded[4]).toEqual(user);
+      expect(decoded[5]).toEqual(params);
+      expect(decoded[6]).toEqual(Number(referralCode));
 
       // gas price
       const gasPrice: GasType | null = await txObj.gas();
@@ -3428,6 +3450,7 @@ describe('Pool', () => {
         minToAmount,
         permitSignature,
         swapAll,
+        onBehalfOf,
         // referralCode,
         augustus,
         swapCallData,
@@ -3447,7 +3470,15 @@ describe('Pool', () => {
       expect(tx.value).toEqual(DEFAULT_NULL_VALUE_ON_TX);
 
       const decoded = utils.defaultAbiCoder.decode(
-        ['address', 'address', 'uint256', 'bytes', 'uint16'],
+        [
+          'address',
+          'address[]',
+          'uint256[]',
+          'uint256[]',
+          'address',
+          'bytes',
+          'uint16',
+        ],
         utils.hexDataSlice(tx.data ?? '', 4),
       );
 
@@ -3477,12 +3508,14 @@ describe('Pool', () => {
       );
 
       expect(decoded[0]).toEqual(SWAP_COLLATERAL_ADAPTER);
-      expect(decoded[1]).toEqual(fromAsset);
-      expect(decoded[2]).toEqual(
+      expect(decoded[1]).toEqual([fromAsset]);
+      expect(decoded[2]).toEqual([
         BigNumber.from(valueToWei(amountWithSurplus, decimals)),
-      );
-      expect(decoded[3]).toEqual(params);
-      expect(decoded[4]).toEqual(0);
+      ]);
+      expect(decoded[3]).toEqual([BigNumber.from(0)]);
+      expect(decoded[4]).toEqual(onBehalfOf);
+      expect(decoded[5]).toEqual(params);
+      expect(decoded[6]).toEqual(0);
 
       // gas price
       const gasPrice: GasType | null = await txObj.gas();
@@ -3510,6 +3543,7 @@ describe('Pool', () => {
         minToAmount,
         permitSignature,
         swapAll,
+        onBehalfOf,
         referralCode,
         augustus,
         swapCallData,
@@ -3529,7 +3563,15 @@ describe('Pool', () => {
       expect(tx.value).toEqual(DEFAULT_NULL_VALUE_ON_TX);
 
       const decoded = utils.defaultAbiCoder.decode(
-        ['address', 'address', 'uint256', 'bytes', 'uint16'],
+        [
+          'address',
+          'address[]',
+          'uint256[]',
+          'uint256[]',
+          'address',
+          'bytes',
+          'uint16',
+        ],
         utils.hexDataSlice(tx.data ?? '', 4),
       );
 
@@ -3559,12 +3601,14 @@ describe('Pool', () => {
       );
 
       expect(decoded[0]).toEqual(SWAP_COLLATERAL_ADAPTER);
-      expect(decoded[1]).toEqual(fromAsset);
-      expect(decoded[2]).toEqual(
+      expect(decoded[1]).toEqual([fromAsset]);
+      expect(decoded[2]).toEqual([
         BigNumber.from(valueToWei(fromAmount, decimals)),
-      );
-      expect(decoded[3]).toEqual(params);
-      expect(decoded[4]).toEqual(Number(referralCode));
+      ]);
+      expect(decoded[3]).toEqual([BigNumber.from(0)]);
+      expect(decoded[4]).toEqual(onBehalfOf);
+      expect(decoded[5]).toEqual(params);
+      expect(decoded[6]).toEqual(Number(referralCode));
 
       // gas price
       const gasPrice: GasType | null = await txObj.gas();
@@ -3595,6 +3639,7 @@ describe('Pool', () => {
         minToAmount,
         // permitSignature,
         swapAll,
+        onBehalfOf,
         referralCode,
         augustus,
         swapCallData,
@@ -3617,6 +3662,7 @@ describe('Pool', () => {
         minToAmount,
         permitSignature,
         swapAll,
+        onBehalfOf,
         referralCode,
         augustus,
         swapCallData,
@@ -3635,6 +3681,7 @@ describe('Pool', () => {
         minToAmount,
         permitSignature,
         swapAll,
+        onBehalfOf,
         referralCode,
         augustus,
         swapCallData,
@@ -3655,6 +3702,7 @@ describe('Pool', () => {
           minToAmount,
           permitSignature,
           swapAll,
+          onBehalfOf,
           referralCode,
           augustus,
           swapCallData,
@@ -3677,6 +3725,7 @@ describe('Pool', () => {
           minToAmount,
           permitSignature,
           swapAll,
+          onBehalfOf,
           referralCode,
           augustus,
           swapCallData,
@@ -3699,6 +3748,7 @@ describe('Pool', () => {
           minToAmount,
           permitSignature,
           swapAll,
+          onBehalfOf,
           referralCode,
           augustus,
           swapCallData,
@@ -3721,12 +3771,36 @@ describe('Pool', () => {
           minToAmount,
           permitSignature,
           swapAll,
+          onBehalfOf,
           referralCode,
           augustus,
           swapCallData,
         }),
       ).rejects.toThrowError(
         `Address: ${toAsset} is not a valid ethereum Address`,
+      );
+    });
+    it('Expects to fail when onBehalfOf not and eth address', async () => {
+      const poolInstance = new Pool(provider, config);
+      const onBehalfOf = 'asdf';
+      await expect(async () =>
+        poolInstance.swapCollateral({
+          user,
+          flash,
+          fromAsset,
+          fromAToken,
+          toAsset,
+          fromAmount,
+          minToAmount,
+          permitSignature,
+          swapAll,
+          onBehalfOf,
+          referralCode,
+          augustus,
+          swapCallData,
+        }),
+      ).rejects.toThrowError(
+        `Address: ${onBehalfOf} is not a valid ethereum Address`,
       );
     });
     it('Expects to fail when augustus not and eth address', async () => {
@@ -3743,6 +3817,7 @@ describe('Pool', () => {
           minToAmount,
           permitSignature,
           swapAll,
+          onBehalfOf,
           referralCode,
           augustus,
           swapCallData,
@@ -3765,6 +3840,7 @@ describe('Pool', () => {
           minToAmount,
           permitSignature,
           swapAll,
+          onBehalfOf,
           referralCode,
           augustus,
           swapCallData,
@@ -3787,6 +3863,7 @@ describe('Pool', () => {
           minToAmount,
           permitSignature,
           swapAll,
+          onBehalfOf,
           referralCode,
           augustus,
           swapCallData,
@@ -3809,6 +3886,7 @@ describe('Pool', () => {
           minToAmount,
           permitSignature,
           swapAll,
+          onBehalfOf,
           referralCode,
           augustus,
           swapCallData,
@@ -3831,6 +3909,7 @@ describe('Pool', () => {
           minToAmount,
           permitSignature,
           swapAll,
+          onBehalfOf,
           referralCode,
           augustus,
           swapCallData,
@@ -3840,11 +3919,13 @@ describe('Pool', () => {
       );
     });
   });
+
   describe('paraswapRepayWithCollateral', () => {
     const user = '0x0000000000000000000000000000000000000006';
     const fromAsset = '0x0000000000000000000000000000000000000007';
     const fromAToken = '0x0000000000000000000000000000000000000008';
     const assetToRepay = '0x0000000000000000000000000000000000000009';
+    const onBehalfOf = '0x0000000000000000000000000000000000000010';
     const augustus = '0x0000000000000000000000000000000000000011';
     const repayWithAmount = '12.34';
     const repayAmount = '13.56';
@@ -3909,6 +3990,7 @@ describe('Pool', () => {
           permitSignature,
           repayAllDebt,
           rateMode,
+          onBehalfOf,
           referralCode,
           flash,
           swapAndRepayCallData,
@@ -3930,7 +4012,15 @@ describe('Pool', () => {
       expect(tx.value).toEqual(DEFAULT_NULL_VALUE_ON_TX);
 
       const decoded = utils.defaultAbiCoder.decode(
-        ['address', 'address', 'uint256', 'bytes', 'uint16'],
+        [
+          'address',
+          'address[]',
+          'uint256[]',
+          'uint256[]',
+          'address',
+          'bytes',
+          'uint16',
+        ],
         utils.hexDataSlice(tx.data ?? '', 4),
       );
 
@@ -3962,12 +4052,14 @@ describe('Pool', () => {
       );
 
       expect(decoded[0]).toEqual(REPAY_WITH_COLLATERAL_ADAPTER);
-      expect(decoded[1]).toEqual(fromAsset);
-      expect(decoded[2]).toEqual(
+      expect(decoded[1]).toEqual([fromAsset]);
+      expect(decoded[2]).toEqual([
         BigNumber.from(valueToWei(repayAmountWithSurplus, decimals)),
-      );
-      expect(decoded[3]).toEqual(params);
-      expect(decoded[4]).toEqual(Number(referralCode));
+      ]);
+      expect(decoded[3]).toEqual([BigNumber.from(0)]);
+      expect(decoded[4]).toEqual(onBehalfOf);
+      expect(decoded[5]).toEqual(params);
+      expect(decoded[6]).toEqual(Number(referralCode));
 
       // gas price
       const gasPrice: GasType | null = await txObj.gas();
@@ -3998,6 +4090,7 @@ describe('Pool', () => {
           permitSignature,
           repayAllDebt,
           rateMode,
+          onBehalfOf,
           referralCode,
           flash,
           swapAndRepayCallData,
@@ -4018,7 +4111,15 @@ describe('Pool', () => {
       expect(tx.value).toEqual(DEFAULT_NULL_VALUE_ON_TX);
 
       const decoded = utils.defaultAbiCoder.decode(
-        ['address', 'address', 'uint256', 'bytes', 'uint16'],
+        [
+          'address',
+          'address[]',
+          'uint256[]',
+          'uint256[]',
+          'address',
+          'bytes',
+          'uint16',
+        ],
         utils.hexDataSlice(tx.data ?? '', 4),
       );
 
@@ -4050,12 +4151,14 @@ describe('Pool', () => {
       );
 
       expect(decoded[0]).toEqual(REPAY_WITH_COLLATERAL_ADAPTER);
-      expect(decoded[1]).toEqual(fromAsset);
-      expect(decoded[2]).toEqual(
+      expect(decoded[1]).toEqual([fromAsset]);
+      expect(decoded[2]).toEqual([
         BigNumber.from(valueToWei(repayAmountWithSurplus, decimals)),
-      );
-      expect(decoded[3]).toEqual(params);
-      expect(decoded[4]).toEqual(Number(referralCode));
+      ]);
+      expect(decoded[3]).toEqual([BigNumber.from(0)]);
+      expect(decoded[4]).toEqual(onBehalfOf);
+      expect(decoded[5]).toEqual(params);
+      expect(decoded[6]).toEqual(Number(referralCode));
 
       // gas price
       const gasPrice: GasType | null = await txObj.gas();
@@ -4084,6 +4187,7 @@ describe('Pool', () => {
           permitSignature,
           repayAllDebt,
           rateMode,
+          onBehalfOf,
           referralCode,
           flash,
           swapAndRepayCallData,
@@ -4104,7 +4208,15 @@ describe('Pool', () => {
       expect(tx.value).toEqual(DEFAULT_NULL_VALUE_ON_TX);
 
       const decoded = utils.defaultAbiCoder.decode(
-        ['address', 'address', 'uint256', 'bytes', 'uint16'],
+        [
+          'address',
+          'address[]',
+          'uint256[]',
+          'uint256[]',
+          'address',
+          'bytes',
+          'uint16',
+        ],
         utils.hexDataSlice(tx.data ?? '', 4),
       );
 
@@ -4136,12 +4248,14 @@ describe('Pool', () => {
       );
 
       expect(decoded[0]).toEqual(REPAY_WITH_COLLATERAL_ADAPTER);
-      expect(decoded[1]).toEqual(fromAsset);
-      expect(decoded[2]).toEqual(
+      expect(decoded[1]).toEqual([fromAsset]);
+      expect(decoded[2]).toEqual([
         BigNumber.from(valueToWei(repayAmountWithSurplus, decimals)),
-      );
-      expect(decoded[3]).toEqual(params);
-      expect(decoded[4]).toEqual(Number(referralCode));
+      ]);
+      expect(decoded[3]).toEqual([BigNumber.from(0)]);
+      expect(decoded[4]).toEqual(onBehalfOf);
+      expect(decoded[5]).toEqual(params);
+      expect(decoded[6]).toEqual(Number(referralCode));
 
       // gas price
       const gasPrice: GasType | null = await txObj.gas();
@@ -4169,6 +4283,7 @@ describe('Pool', () => {
           permitSignature,
           repayAllDebt,
           rateMode,
+          // onBehalfOf,
           referralCode,
           flash,
           swapAndRepayCallData,
@@ -4189,7 +4304,15 @@ describe('Pool', () => {
       expect(tx.value).toEqual(DEFAULT_NULL_VALUE_ON_TX);
 
       const decoded = utils.defaultAbiCoder.decode(
-        ['address', 'address', 'uint256', 'bytes', 'uint16'],
+        [
+          'address',
+          'address[]',
+          'uint256[]',
+          'uint256[]',
+          'address',
+          'bytes',
+          'uint16',
+        ],
         utils.hexDataSlice(tx.data ?? '', 4),
       );
 
@@ -4221,12 +4344,14 @@ describe('Pool', () => {
       );
 
       expect(decoded[0]).toEqual(REPAY_WITH_COLLATERAL_ADAPTER);
-      expect(decoded[1]).toEqual(fromAsset);
-      expect(decoded[2]).toEqual(
+      expect(decoded[1]).toEqual([fromAsset]);
+      expect(decoded[2]).toEqual([
         BigNumber.from(valueToWei(repayAmountWithSurplus, decimals)),
-      );
-      expect(decoded[3]).toEqual(params);
-      expect(decoded[4]).toEqual(Number(referralCode));
+      ]);
+      expect(decoded[3]).toEqual([BigNumber.from(0)]);
+      expect(decoded[4]).toEqual(user);
+      expect(decoded[5]).toEqual(params);
+      expect(decoded[6]).toEqual(Number(referralCode));
 
       // gas price
       const gasPrice: GasType | null = await txObj.gas();
@@ -4254,6 +4379,7 @@ describe('Pool', () => {
           permitSignature,
           repayAllDebt,
           rateMode,
+          onBehalfOf,
           // referralCode,
           flash,
           swapAndRepayCallData,
@@ -4274,7 +4400,15 @@ describe('Pool', () => {
       expect(tx.value).toEqual(DEFAULT_NULL_VALUE_ON_TX);
 
       const decoded = utils.defaultAbiCoder.decode(
-        ['address', 'address', 'uint256', 'bytes', 'uint16'],
+        [
+          'address',
+          'address[]',
+          'uint256[]',
+          'uint256[]',
+          'address',
+          'bytes',
+          'uint16',
+        ],
         utils.hexDataSlice(tx.data ?? '', 4),
       );
 
@@ -4306,12 +4440,14 @@ describe('Pool', () => {
       );
 
       expect(decoded[0]).toEqual(REPAY_WITH_COLLATERAL_ADAPTER);
-      expect(decoded[1]).toEqual(fromAsset);
-      expect(decoded[2]).toEqual(
+      expect(decoded[1]).toEqual([fromAsset]);
+      expect(decoded[2]).toEqual([
         BigNumber.from(valueToWei(repayAmountWithSurplus, decimals)),
-      );
-      expect(decoded[3]).toEqual(params);
-      expect(decoded[4]).toEqual(0);
+      ]);
+      expect(decoded[3]).toEqual([BigNumber.from(0)]);
+      expect(decoded[4]).toEqual(onBehalfOf);
+      expect(decoded[5]).toEqual(params);
+      expect(decoded[6]).toEqual(0);
 
       // gas price
       const gasPrice: GasType | null = await txObj.gas();
@@ -4339,6 +4475,7 @@ describe('Pool', () => {
           permitSignature,
           // repayAllDebt,
           rateMode,
+          onBehalfOf,
           referralCode,
           flash,
           swapAndRepayCallData,
@@ -4359,7 +4496,15 @@ describe('Pool', () => {
       expect(tx.value).toEqual(DEFAULT_NULL_VALUE_ON_TX);
 
       const decoded = utils.defaultAbiCoder.decode(
-        ['address', 'address', 'uint256', 'bytes', 'uint16'],
+        [
+          'address',
+          'address[]',
+          'uint256[]',
+          'uint256[]',
+          'address',
+          'bytes',
+          'uint16',
+        ],
         utils.hexDataSlice(tx.data ?? '', 4),
       );
 
@@ -4391,12 +4536,14 @@ describe('Pool', () => {
       );
 
       expect(decoded[0]).toEqual(REPAY_WITH_COLLATERAL_ADAPTER);
-      expect(decoded[1]).toEqual(fromAsset);
-      expect(decoded[2]).toEqual(
+      expect(decoded[1]).toEqual([fromAsset]);
+      expect(decoded[2]).toEqual([
         BigNumber.from(valueToWei(repayWithAmount, decimals)),
-      );
-      expect(decoded[3]).toEqual(params);
-      expect(decoded[4]).toEqual(Number(referralCode));
+      ]);
+      expect(decoded[3]).toEqual([BigNumber.from(0)]);
+      expect(decoded[4]).toEqual(onBehalfOf);
+      expect(decoded[5]).toEqual(params);
+      expect(decoded[6]).toEqual(Number(referralCode));
 
       // gas price
       const gasPrice: GasType | null = await txObj.gas();
@@ -4430,6 +4577,7 @@ describe('Pool', () => {
         // permitSignature,
         repayAllDebt,
         rateMode,
+        onBehalfOf,
         referralCode,
         // flash,
         swapAndRepayCallData,
@@ -4466,6 +4614,7 @@ describe('Pool', () => {
         permitSignature,
         // repayAllDebt,
         rateMode,
+        onBehalfOf,
         referralCode,
         // flash,
         swapAndRepayCallData,
@@ -4488,6 +4637,7 @@ describe('Pool', () => {
         permitSignature,
         repayAllDebt,
         rateMode,
+        onBehalfOf,
         referralCode,
         flash,
         swapAndRepayCallData,
@@ -4507,6 +4657,7 @@ describe('Pool', () => {
         permitSignature,
         repayAllDebt,
         rateMode,
+        onBehalfOf,
         referralCode,
         flash,
         swapAndRepayCallData,
@@ -4528,6 +4679,7 @@ describe('Pool', () => {
           permitSignature,
           repayAllDebt,
           rateMode,
+          onBehalfOf,
           referralCode,
           flash,
           swapAndRepayCallData,
@@ -4551,6 +4703,7 @@ describe('Pool', () => {
           permitSignature,
           repayAllDebt,
           rateMode,
+          onBehalfOf,
           referralCode,
           flash,
           swapAndRepayCallData,
@@ -4574,6 +4727,7 @@ describe('Pool', () => {
           permitSignature,
           repayAllDebt,
           rateMode,
+          onBehalfOf,
           referralCode,
           flash,
           swapAndRepayCallData,
@@ -4597,6 +4751,7 @@ describe('Pool', () => {
           permitSignature,
           repayAllDebt,
           rateMode,
+          onBehalfOf,
           referralCode,
           flash,
           swapAndRepayCallData,
@@ -4620,6 +4775,7 @@ describe('Pool', () => {
           permitSignature,
           repayAllDebt,
           rateMode,
+          onBehalfOf,
           referralCode,
           flash,
           swapAndRepayCallData,
@@ -4627,6 +4783,30 @@ describe('Pool', () => {
         }),
       ).rejects.toThrowError(
         `Address: ${assetToRepay} is not a valid ethereum Address`,
+      );
+    });
+    it('Expects to fail when onBehalfOf not and eth address', async () => {
+      const poolInstance = new Pool(provider, config);
+      const onBehalfOf = 'asdf';
+      await expect(async () =>
+        poolInstance.paraswapRepayWithCollateral({
+          user,
+          fromAsset,
+          fromAToken,
+          assetToRepay,
+          repayWithAmount,
+          repayAmount,
+          permitSignature,
+          repayAllDebt,
+          rateMode,
+          onBehalfOf,
+          referralCode,
+          flash,
+          swapAndRepayCallData,
+          augustus,
+        }),
+      ).rejects.toThrowError(
+        `Address: ${onBehalfOf} is not a valid ethereum Address`,
       );
     });
     it('Expects to fail when repayWithAmount not positive', async () => {
@@ -4643,6 +4823,7 @@ describe('Pool', () => {
           permitSignature,
           repayAllDebt,
           rateMode,
+          onBehalfOf,
           referralCode,
           flash,
           swapAndRepayCallData,
@@ -4666,6 +4847,7 @@ describe('Pool', () => {
           permitSignature,
           repayAllDebt,
           rateMode,
+          onBehalfOf,
           referralCode,
           flash,
           swapAndRepayCallData,
@@ -4689,6 +4871,7 @@ describe('Pool', () => {
           permitSignature,
           repayAllDebt,
           rateMode,
+          onBehalfOf,
           referralCode,
           flash,
           swapAndRepayCallData,
@@ -4712,6 +4895,7 @@ describe('Pool', () => {
           permitSignature,
           repayAllDebt,
           rateMode,
+          onBehalfOf,
           referralCode,
           flash,
           swapAndRepayCallData,
@@ -4773,7 +4957,15 @@ describe('Pool', () => {
       expect(tx.value).toEqual(DEFAULT_NULL_VALUE_ON_TX);
 
       const decoded = utils.defaultAbiCoder.decode(
-        ['address', 'address', 'uint256', 'bytes', 'uint16'],
+        [
+          'address',
+          'address[]',
+          'uint256[]',
+          'uint256[]',
+          'address',
+          'bytes',
+          'uint16',
+        ],
         utils.hexDataSlice(tx.data ?? '', 4),
       );
 
@@ -4789,12 +4981,14 @@ describe('Pool', () => {
       );
 
       expect(decoded[0]).toEqual(FLASH_LIQUIDATION_ADAPTER);
-      expect(decoded[1]).toEqual(borrowedAsset);
-      expect(decoded[2]).toEqual(
+      expect(decoded[1]).toEqual([borrowedAsset]);
+      expect(decoded[2]).toEqual([
         BigNumber.from(valueToWei(amountSurplus, decimals)),
-      );
-      expect(decoded[3]).toEqual(params);
-      expect(decoded[4]).toEqual(0);
+      ]);
+      expect(decoded[3]).toEqual([BigNumber.from(0)]);
+      expect(decoded[4]).toEqual(initiator);
+      expect(decoded[5]).toEqual(params);
+      expect(decoded[6]).toEqual(0);
 
       // gas price
       const gasPrice: GasType | null = await txObj.gas();
@@ -4831,7 +5025,15 @@ describe('Pool', () => {
       expect(tx.value).toEqual(DEFAULT_NULL_VALUE_ON_TX);
 
       const decoded = utils.defaultAbiCoder.decode(
-        ['address', 'address', 'uint256', 'bytes', 'uint16'],
+        [
+          'address',
+          'address[]',
+          'uint256[]',
+          'uint256[]',
+          'address',
+          'bytes',
+          'uint16',
+        ],
         utils.hexDataSlice(tx.data ?? '', 4),
       );
 
@@ -4847,12 +5049,14 @@ describe('Pool', () => {
       );
 
       expect(decoded[0]).toEqual(FLASH_LIQUIDATION_ADAPTER);
-      expect(decoded[1]).toEqual(borrowedAsset);
-      expect(decoded[2]).toEqual(
+      expect(decoded[1]).toEqual([borrowedAsset]);
+      expect(decoded[2]).toEqual([
         BigNumber.from(valueToWei(amountSurplus, decimals)),
-      );
-      expect(decoded[3]).toEqual(params);
-      expect(decoded[4]).toEqual(0);
+      ]);
+      expect(decoded[3]).toEqual([BigNumber.from(0)]);
+      expect(decoded[4]).toEqual(initiator);
+      expect(decoded[5]).toEqual(params);
+      expect(decoded[6]).toEqual(0);
 
       // gas price
       const gasPrice: GasType | null = await txObj.gas();
@@ -4890,7 +5094,15 @@ describe('Pool', () => {
       expect(tx.value).toEqual(DEFAULT_NULL_VALUE_ON_TX);
 
       const decoded = utils.defaultAbiCoder.decode(
-        ['address', 'address', 'uint256', 'bytes', 'uint16'],
+        [
+          'address',
+          'address[]',
+          'uint256[]',
+          'uint256[]',
+          'address',
+          'bytes',
+          'uint16',
+        ],
         utils.hexDataSlice(tx.data ?? '', 4),
       );
 
@@ -4906,12 +5118,14 @@ describe('Pool', () => {
       );
 
       expect(decoded[0]).toEqual(FLASH_LIQUIDATION_ADAPTER);
-      expect(decoded[1]).toEqual(borrowedAsset);
-      expect(decoded[2]).toEqual(
+      expect(decoded[1]).toEqual([borrowedAsset]);
+      expect(decoded[2]).toEqual([
         BigNumber.from(valueToWei(debtTokenCover, decimals)),
-      );
-      expect(decoded[3]).toEqual(params);
-      expect(decoded[4]).toEqual(0);
+      ]);
+      expect(decoded[3]).toEqual([BigNumber.from(0)]);
+      expect(decoded[4]).toEqual(initiator);
+      expect(decoded[5]).toEqual(params);
+      expect(decoded[6]).toEqual(0);
 
       // gas price
       const gasPrice: GasType | null = await txObj.gas();


### PR DESCRIPTION
Reverts #338 

Simple flashloans can't be used for the paraswap adapters without changing the adapter contracts as well. The `executeOperation` function of the [adapter](https://github.com/aave/aave-v3-periphery/blob/ca184e5278bcbc10d28c3dbbc604041d7cfac50b/contracts/adapters/paraswap/ParaSwapLiquiditySwapAdapter.sol#L45) is expecting batch inputs, and any transaction which calls this contract with the flashloanSimple inputs will revert.