### PR TITLE
fix: remove static interface and use emitted instead [RFC]

### DIFF
--- a/packages/contract-helpers/src/v3-pool-contract/index.ts
+++ b/packages/contract-helpers/src/v3-pool-contract/index.ts
@@ -66,53 +66,6 @@ import {
 import { IPool } from './typechain/IPool';
 import { IPool__factory } from './typechain/IPool__factory';
 
-export interface PoolInterface {
-  deposit: (
-    args: LPSupplyParamsType,
-  ) => Promise<EthereumTransactionTypeExtended[]>;
-  supply: (
-    args: LPSupplyParamsType,
-  ) => Promise<EthereumTransactionTypeExtended[]>;
-  signERC20Approval: (args: LPSignERC20ApprovalType) => Promise<string>;
-  supplyWithPermit: (
-    args: LPSupplyWithPermitType,
-  ) => Promise<EthereumTransactionTypeExtended[]>;
-  withdraw: (
-    args: LPWithdrawParamsType,
-  ) => Promise<EthereumTransactionTypeExtended[]>;
-  borrow: (
-    args: LPBorrowParamsType,
-  ) => Promise<EthereumTransactionTypeExtended[]>;
-  repay: (
-    args: LPRepayParamsType,
-  ) => Promise<EthereumTransactionTypeExtended[]>;
-  repayWithPermit: (
-    args: LPRepayWithPermitParamsType,
-  ) => Promise<EthereumTransactionTypeExtended[]>;
-  swapBorrowRateMode: (
-    args: LPSwapBorrowRateMode,
-  ) => Promise<EthereumTransactionTypeExtended[]>;
-  setUsageAsCollateral: (
-    args: LPSetUsageAsCollateral,
-  ) => Promise<EthereumTransactionTypeExtended[]>;
-  swapCollateral: (
-    args: LPSwapCollateral,
-  ) => Promise<EthereumTransactionTypeExtended[]>;
-  flashLiquidation: (
-    args: LPFlashLiquidation,
-  ) => Promise<EthereumTransactionTypeExtended[]>;
-  repayWithATokens: (
-    args: LPRepayWithATokensType,
-  ) => Promise<EthereumTransactionTypeExtended[]>;
-  liquidationCall: (
-    args: LPLiquidationCall,
-  ) => Promise<EthereumTransactionTypeExtended[]>;
-  setUserEMode: (args: LPSetUserEModeType) => EthereumTransactionTypeExtended[];
-  paraswapRepayWithCollateral(
-    args: LPParaswapRepayWithCollateral,
-  ): Promise<EthereumTransactionTypeExtended[]>;
-}
-
 export type LendingPoolMarketConfigV3 = {
   POOL: tEthereumAddress;
   WETH_GATEWAY?: tEthereumAddress;
@@ -155,7 +108,7 @@ const buildParaSwapLiquiditySwapParams = (
   );
 };
 
-export class Pool extends BaseService<IPool> implements PoolInterface {
+export class Pool extends BaseService<IPool> {
   readonly erc20Service: IERC20ServiceInterface;
 
   readonly poolAddress: string;
@@ -890,11 +843,11 @@ export class Pool extends BaseService<IPool> implements PoolInterface {
   }
 
   @LPValidatorV3
-  public async swapBorrowRateMode(
+  public swapBorrowRateMode(
     @isEthAddress('user')
     @isEthAddress('reserve')
     { user, reserve, interestRateMode, useOptimizedPath }: LPSwapBorrowRateMode,
-  ): Promise<EthereumTransactionTypeExtended[]> {
+  ) {
     const numericRateMode = interestRateMode === InterestRate.Variable ? 2 : 1;
 
     if (useOptimizedPath) {
@@ -925,7 +878,7 @@ export class Pool extends BaseService<IPool> implements PoolInterface {
   }
 
   @LPValidatorV3
-  public async setUsageAsCollateral(
+  public setUsageAsCollateral(
     @isEthAddress('user')
     @isEthAddress('reserve')
     {
@@ -934,7 +887,7 @@ export class Pool extends BaseService<IPool> implements PoolInterface {
       usageAsCollateral,
       useOptimizedPath,
     }: LPSetUsageAsCollateral,
-  ): Promise<EthereumTransactionTypeExtended[]> {
+  ) {
     const poolContract: IPool = this.getContractInstance(this.poolAddress);
 
     if (useOptimizedPath) {


### PR DESCRIPTION
tl;dr;
remove statically typed interfaces as they do more harm than help

I've spend quite some time today fighting with types, and in the end it turned out the inaccurate types come from here.

In utilities we define interfaces which are implemented in classes.
(In my eyes) this only makes sense when the interfaces are reused and multiple classes implement the same interface.
In this case though each interface is only implemented once and in some cases they are incomplete.

This imo is a bit unreasonable and a self created maintenance burden.
Instead of using the `PoolInterface` you can just use the emitted `Pool` type and instead of specifying the return type you can infer it.

`setUsageAsCollateral` for example does not always return a promise, but can return a promise<extendedTxn[]> or `extendedTxn[]`.
Wdyt? Should we drop the manually maintained interfaces?