### PR TITLE
chore: update discount rate strategy source

### DIFF
--- a/packages/contract-helpers/src/gho/GhoDiscountRateStrategyService.ts
+++ b/packages/contract-helpers/src/gho/GhoDiscountRateStrategyService.ts
@@ -1,5 +1,9 @@
 import { BigNumber, BigNumberish, providers } from 'ethers';
 import BaseService from '../commons/BaseService';
+import {
+  GhoVariableDebtTokenService,
+  IGhoVariableDebtTokenService,
+} from './GhoVariableDebtTokenService';
 import type { GhoDiscountRateStrategy } from './typechain/GhoDiscountRateStrategy';
 import { GhoDiscountRateStrategy__factory } from './typechain/GhoDiscountRateStrategy__factory';
 
@@ -22,14 +26,17 @@ export class GhoDiscountRateStrategyService
   extends BaseService<GhoDiscountRateStrategy>
   implements IGhoDiscountRateStrategyService
 {
-  readonly ghoDiscountRateStrategyAddress: string;
+  readonly ghoVariableDebtTokenService: IGhoVariableDebtTokenService;
 
   constructor(
     provider: providers.Provider,
-    discountRateStrategyAddress: string,
+    ghoVariableDebtTokenAddress: string,
   ) {
     super(provider, GhoDiscountRateStrategy__factory);
-    this.ghoDiscountRateStrategyAddress = discountRateStrategyAddress;
+    this.ghoVariableDebtTokenService = new GhoVariableDebtTokenService(
+      provider,
+      ghoVariableDebtTokenAddress,
+    );
   }
 
   /**
@@ -37,9 +44,9 @@ export class GhoDiscountRateStrategyService
    * @returns - A BigNumber representing the amount of GHO tokens per discount token that are eligible to be discounted, expressed with the number of decimals of the discount token
    */
   public async getGhoDiscountedPerDiscountToken() {
-    const contract = this.getContractInstance(
-      this.ghoDiscountRateStrategyAddress,
-    );
+    const ghoDiscountRateStrategyAddress =
+      await this.ghoVariableDebtTokenService.getDiscountRateStrategy();
+    const contract = this.getContractInstance(ghoDiscountRateStrategyAddress);
     // eslint-disable-next-line new-cap
     const result = await contract.GHO_DISCOUNTED_PER_DISCOUNT_TOKEN();
     return result;
@@ -50,9 +57,9 @@ export class GhoDiscountRateStrategyService
    * @returns - A BigNumber representing the current maximum discount rate, expressed in bps, a value of 2000 results in 20.00%
    */
   public async getGhoDiscountRate() {
-    const contract = this.getContractInstance(
-      this.ghoDiscountRateStrategyAddress,
-    );
+    const ghoDiscountRateStrategyAddress =
+      await this.ghoVariableDebtTokenService.getDiscountRateStrategy();
+    const contract = this.getContractInstance(ghoDiscountRateStrategyAddress);
     // eslint-disable-next-line new-cap
     const result = await contract.DISCOUNT_RATE();
     return result;
@@ -63,9 +70,9 @@ export class GhoDiscountRateStrategyService
    * @returns - A BigNumber representing the minimum amount of discount tokens needed to be eligible for a discount, expressed with the number of decimals of the discount token
    */
   public async getGhoMinDiscountTokenBalance() {
-    const contract = this.getContractInstance(
-      this.ghoDiscountRateStrategyAddress,
-    );
+    const ghoDiscountRateStrategyAddress =
+      await this.ghoVariableDebtTokenService.getDiscountRateStrategy();
+    const contract = this.getContractInstance(ghoDiscountRateStrategyAddress);
     // eslint-disable-next-line new-cap
     const result = await contract.MIN_DISCOUNT_TOKEN_BALANCE();
     return result;
@@ -76,9 +83,9 @@ export class GhoDiscountRateStrategyService
    * @returns - A BigNumber representing the minimum amount of debt tokens needed to be eligible for a discount, expressed with the number of decimals of the debt token
    */
   public async getGhoMinDebtTokenBalance() {
-    const contract = this.getContractInstance(
-      this.ghoDiscountRateStrategyAddress,
-    );
+    const ghoDiscountRateStrategyAddress =
+      await this.ghoVariableDebtTokenService.getDiscountRateStrategy();
+    const contract = this.getContractInstance(ghoDiscountRateStrategyAddress);
     // eslint-disable-next-line new-cap
     const result = await contract.MIN_DEBT_TOKEN_BALANCE();
     return result;
@@ -94,9 +101,9 @@ export class GhoDiscountRateStrategyService
     ghoDebtTokenBalance: BigNumberish,
     stakedAaveBalance: BigNumberish,
   ) {
-    const contract = this.getContractInstance(
-      this.ghoDiscountRateStrategyAddress,
-    );
+    const ghoDiscountRateStrategyAddress =
+      await this.ghoVariableDebtTokenService.getDiscountRateStrategy();
+    const contract = this.getContractInstance(ghoDiscountRateStrategyAddress);
     const result = await contract.calculateDiscountRate(
       ghoDebtTokenBalance,
       stakedAaveBalance,

--- a/packages/contract-helpers/src/gho/GhoVariableDebtTokenService.ts
+++ b/packages/contract-helpers/src/gho/GhoVariableDebtTokenService.ts
@@ -3,11 +3,12 @@ import BaseService from '../commons/BaseService';
 import { GhoVariableDebtToken__factory } from './typechain/GhoVariableDebtToken__factory';
 import type { IGhoVariableDebtToken } from './typechain/IGhoVariableDebtToken';
 
-interface IGhoVariableDebtTokenService {
+export interface IGhoVariableDebtTokenService {
   getDiscountToken: () => Promise<string>;
   getDiscountLockPeriod: () => Promise<BigNumber>;
   getUserDiscountPercent: (userAddress: string) => Promise<BigNumber>;
   getUserRebalanceTimestamp: (userAddress: string) => Promise<BigNumber>;
+  getDiscountRateStrategy: () => Promise<string>;
 }
 
 /**
@@ -68,6 +69,16 @@ export class GhoVariableDebtTokenService
   public async getUserRebalanceTimestamp(userAddress: string) {
     const contract = this.getContractInstance(this.ghoVariableDebtTokenAddress);
     const result = await contract.getUserRebalanceTimestamp(userAddress);
+    return result;
+  }
+
+  /**
+   * Gets the discount rate strategy currently in use
+   * @returns - Address of current GhoDiscountRateStrategy
+   */
+  public async getDiscountRateStrategy() {
+    const contract = this.getContractInstance(this.ghoVariableDebtTokenAddress);
+    const result = await contract.getDiscountRateStrategy();
     return result;
   }
 }

--- a/packages/contract-helpers/src/gho/__tests__/GhoDiscountRateStrategyService.test.ts
+++ b/packages/contract-helpers/src/gho/__tests__/GhoDiscountRateStrategyService.test.ts
@@ -3,6 +3,8 @@ import { valueToWei } from '../../commons/utils';
 import { GhoDiscountRateStrategyService } from '../GhoDiscountRateStrategyService';
 import { GhoDiscountRateStrategy } from '../typechain/GhoDiscountRateStrategy';
 import { GhoDiscountRateStrategy__factory } from '../typechain/GhoDiscountRateStrategy__factory';
+import { GhoVariableDebtToken } from '../typechain/GhoVariableDebtToken';
+import { GhoVariableDebtToken__factory } from '../typechain/GhoVariableDebtToken__factory';
 
 jest.mock('../../commons/gasStation', () => {
   return {
@@ -18,13 +20,18 @@ jest.mock('../../commons/gasStation', () => {
 const convertToBN = (n: string) => valueToWei(n, 18);
 
 describe('GhoDiscountRateStrategyService', () => {
-  const DISCOUNT_RATE_STRATEGY_ADDRESS = constants.AddressZero;
+  const GHO_VARIABLE_DEBT_TOKEN_ADDRESS = constants.AddressZero;
   const correctProvider: providers.Provider = new providers.JsonRpcProvider();
 
   // Mocking
   jest
     .spyOn(correctProvider, 'getGasPrice')
     .mockImplementation(async () => Promise.resolve(BigNumber.from(1)));
+
+  // Mock the response of GhoVariableDebtToken.getDiscountRateStrategy()
+  jest.spyOn(GhoVariableDebtToken__factory, 'connect').mockReturnValue({
+    getDiscountRateStrategy: async () => Promise.resolve(constants.AddressZero),
+  } as unknown as GhoVariableDebtToken);
 
   afterEach(() => jest.clearAllMocks());
 
@@ -33,7 +40,7 @@ describe('GhoDiscountRateStrategyService', () => {
       // Create instance
       const instance = new GhoDiscountRateStrategyService(
         correctProvider,
-        DISCOUNT_RATE_STRATEGY_ADDRESS,
+        GHO_VARIABLE_DEBT_TOKEN_ADDRESS,
       );
 
       // Assert it
@@ -46,7 +53,7 @@ describe('GhoDiscountRateStrategyService', () => {
       // Create instance
       const contract = new GhoDiscountRateStrategyService(
         correctProvider,
-        DISCOUNT_RATE_STRATEGY_ADDRESS,
+        GHO_VARIABLE_DEBT_TOKEN_ADDRESS,
       );
 
       // Setup
@@ -75,7 +82,7 @@ describe('GhoDiscountRateStrategyService', () => {
       // Create instance
       const contract = new GhoDiscountRateStrategyService(
         correctProvider,
-        DISCOUNT_RATE_STRATEGY_ADDRESS,
+        GHO_VARIABLE_DEBT_TOKEN_ADDRESS,
       );
 
       // Setup
@@ -103,7 +110,7 @@ describe('GhoDiscountRateStrategyService', () => {
       // Create instance
       const contract = new GhoDiscountRateStrategyService(
         correctProvider,
-        DISCOUNT_RATE_STRATEGY_ADDRESS,
+        GHO_VARIABLE_DEBT_TOKEN_ADDRESS,
       );
 
       // Setup
@@ -132,7 +139,7 @@ describe('GhoDiscountRateStrategyService', () => {
       // Create instance
       const contract = new GhoDiscountRateStrategyService(
         correctProvider,
-        DISCOUNT_RATE_STRATEGY_ADDRESS,
+        GHO_VARIABLE_DEBT_TOKEN_ADDRESS,
       );
 
       // Setup
@@ -161,7 +168,7 @@ describe('GhoDiscountRateStrategyService', () => {
       // Create instance
       const contract = new GhoDiscountRateStrategyService(
         correctProvider,
-        DISCOUNT_RATE_STRATEGY_ADDRESS,
+        GHO_VARIABLE_DEBT_TOKEN_ADDRESS,
       );
 
       // Use case - borrowing 100 GHO owning 0 skAAVE
@@ -192,7 +199,7 @@ describe('GhoDiscountRateStrategyService', () => {
       // Create instance
       const contract = new GhoDiscountRateStrategyService(
         correctProvider,
-        DISCOUNT_RATE_STRATEGY_ADDRESS,
+        GHO_VARIABLE_DEBT_TOKEN_ADDRESS,
       );
 
       // Use case - borrowing 0 GHO owning 1 skAAVE
@@ -224,7 +231,7 @@ describe('GhoDiscountRateStrategyService', () => {
       // Create instance
       const contract = new GhoDiscountRateStrategyService(
         correctProvider,
-        DISCOUNT_RATE_STRATEGY_ADDRESS,
+        GHO_VARIABLE_DEBT_TOKEN_ADDRESS,
       );
 
       // Use case #1 - borrowing 100 GHO owning 1 stkAAVE
@@ -269,7 +276,7 @@ describe('GhoDiscountRateStrategyService', () => {
       // Create instance
       const contract = new GhoDiscountRateStrategyService(
         correctProvider,
-        DISCOUNT_RATE_STRATEGY_ADDRESS,
+        GHO_VARIABLE_DEBT_TOKEN_ADDRESS,
       );
 
       // Use case - borrowing 150 GHO owning 1 skAAVE

--- a/packages/contract-helpers/src/gho/__tests__/GhoVariableDebtTokenService.test.ts
+++ b/packages/contract-helpers/src/gho/__tests__/GhoVariableDebtTokenService.test.ts
@@ -158,4 +158,33 @@ describe('GhoVariableDebtTokenService', () => {
       expect(result).toEqual(mockUserRebalanceTimestamp);
     });
   });
+
+  describe('getDiscountRateStrategy', () => {
+    it('should return the current discount rate strategy address', async () => {
+      // Create instance
+      const contract = new GhoVariableDebtTokenService(
+        correctProvider,
+        GHO_VARIABLE_DEBT_TOKEN_ADDRESS,
+      );
+
+      // Setup
+      const mockDiscountRateStrategy = constants.AddressZero;
+
+      // Mock it
+      const spy = jest
+        .spyOn(GhoVariableDebtToken__factory, 'connect')
+        .mockReturnValue({
+          getDiscountRateStrategy: async () =>
+            Promise.resolve(mockDiscountRateStrategy),
+        } as unknown as GhoVariableDebtToken);
+
+      // Call it
+      const result = await contract.getDiscountRateStrategy();
+
+      // Assert it
+      expect(spy).toHaveBeenCalled();
+      expect(spy).toBeCalledTimes(1);
+      expect(result).toEqual(mockDiscountRateStrategy);
+    });
+  });
 });


### PR DESCRIPTION
Use `GhoVariableDebtToken.getDiscountRateStrategy()` as the source of truth for discount strategy address instead of hardcoding into a config an address which could be updated in the future.