### PR TITLE
feat: add default gas estimation for permit actions

### DIFF
--- a/packages/contract-helpers/src/commons/types.ts
+++ b/packages/contract-helpers/src/commons/types.ts
@@ -103,6 +103,8 @@ export enum ProtocolAction {
   repayCollateral = 'repayCollateral',
   withdrawETH = 'withdrawETH',
   borrowETH = 'borrwoETH',
+  supplyWithPermit = 'supplyWithPermit',
+  repayWithPermit = 'repayWithPermit',
 }
 
 export enum GovernanceVote {

--- a/packages/contract-helpers/src/commons/utils.ts
+++ b/packages/contract-helpers/src/commons/utils.ts
@@ -78,6 +78,14 @@ export const gasLimitRecommendations: GasRecommendationType = {
     limit: '700000',
     recommended: '700000',
   },
+  [ProtocolAction.supplyWithPermit]: {
+    limit: '350000',
+    recommended: '350000',
+  },
+  [ProtocolAction.repayWithPermit]: {
+    limit: '350000',
+    recommended: '350000',
+  },
 };
 
 export const mintAmountsPerToken: Record<string, string> = {


### PR DESCRIPTION
- Adds default gasLimit values for `supplyWithPermit` and `repayWithPermit`, estimated using median values over last 90 days from Tenderly contract analytics