### PR TITLE
chore: update staking permit

### DIFF
--- a/packages/contract-helpers/src/commons/types.ts
+++ b/packages/contract-helpers/src/commons/types.ts
@@ -107,6 +107,8 @@ export enum ProtocolAction {
   migrateV3 = 'migrateV3',
   supplyWithPermit = 'supplyWithPermit',
   repayWithPermit = 'repayWithPermit',
+  stake = 'stake',
+  stakeWithPermit = 'stakeWithPermit',
 }
 
 export enum GovernanceVote {

--- a/packages/contract-helpers/src/commons/utils.ts
+++ b/packages/contract-helpers/src/commons/utils.ts
@@ -90,6 +90,14 @@ export const gasLimitRecommendations: GasRecommendationType = {
     limit: '350000',
     recommended: '350000',
   },
+  [ProtocolAction.stake]: {
+    limit: '350000',
+    recommended: '350000',
+  },
+  [ProtocolAction.stakeWithPermit]: {
+    limit: '400000',
+    recommended: '400000',
+  },
 };
 
 export const mintAmountsPerToken: Record<string, string> = {

--- a/packages/contract-helpers/src/staking-contract/index.ts
+++ b/packages/contract-helpers/src/staking-contract/index.ts
@@ -41,7 +41,11 @@ export interface StakingInterface {
     user: tEthereumAddress,
     amount: string,
   ) => Promise<EthereumTransactionTypeExtended[]>;
-  signStaking: (user: tEthereumAddress, amount: string) => Promise<string>;
+  signStaking: (
+    user: tEthereumAddress,
+    amount: string,
+    deadline: string,
+  ) => Promise<string>;
   stakeWithPermit: (
     user: tEthereumAddress,
     amount: string,
@@ -94,6 +98,7 @@ export class StakingService
   public async signStaking(
     @isEthAddress() user: tEthereumAddress,
     @isPositiveAmount() amount: string,
+    deadline: string,
   ): Promise<string> {
     const { getTokenData } = this.erc20Service;
     const stakingContract: IStakedToken = this.getContractInstance(
@@ -142,7 +147,7 @@ export class StakingService
         spender: this.stakingHelperContractAddress,
         value: convertedAmount,
         nonce,
-        deadline: constants.MaxUint256.toString(),
+        deadline,
       },
     };
 

--- a/packages/contract-helpers/src/staking-contract/index.ts
+++ b/packages/contract-helpers/src/staking-contract/index.ts
@@ -98,7 +98,6 @@ export class StakingService
   public async signStaking(
     @isEthAddress() user: tEthereumAddress,
     @isPositiveAmount() amount: string,
-    deadline: string,
   ): Promise<string> {
     const { getTokenData } = this.erc20Service;
     const stakingContract: IStakedToken = this.getContractInstance(
@@ -147,7 +146,7 @@ export class StakingService
         spender: this.stakingHelperContractAddress,
         value: convertedAmount,
         nonce,
-        deadline,
+        deadline: constants.MaxUint256.toString(),
       },
     };
 

--- a/packages/contract-helpers/src/staking-contract/staking.test.ts
+++ b/packages/contract-helpers/src/staking-contract/staking.test.ts
@@ -156,29 +156,35 @@ describe('StakingService', () => {
         instance.signStaking(user, amount, deadline),
       ).rejects.toThrowError(`Amount: ${amount} needs to be greater than 0`);
     });
-    it('Expects to fail when nonce not positive or 0', async () => {
+    it('Expects the permission string to be `` when no nonce', async () => {
       const instance = new StakingService(provider, {
         TOKEN_STAKING_ADDRESS,
         STAKING_HELPER_ADDRESS,
       });
-      const nonce = '-1';
-      await expect(async () =>
-        instance.signStaking(user, amount, deadline),
-      ).rejects.toThrowError(
-        `Amount: ${nonce} needs to be greater or equal than 0`,
+      jest.spyOn(instance.erc20Service, 'getTokenData').mockReturnValue(
+        Promise.resolve({
+          name: 'mockToken',
+          decimals,
+          symbol: 'MT',
+          address: '0x0000000000000000000000000000000000000006',
+        }),
       );
-    });
-    it('Expects to fail when nonce not number', async () => {
-      const instance = new StakingService(provider, {
-        TOKEN_STAKING_ADDRESS,
-        STAKING_HELPER_ADDRESS,
-      });
-      const nonce = 'asdf';
-      await expect(async () =>
-        instance.signStaking(user, amount, deadline),
-      ).rejects.toThrowError(
-        `Amount: ${nonce} needs to be greater or equal than 0`,
+      jest.spyOn(IStakedToken__factory, 'connect').mockReturnValue({
+        STAKED_TOKEN: async () =>
+          Promise.resolve('0x0000000000000000000000000000000000000006'),
+      } as unknown as IStakedToken);
+
+      jest
+        .spyOn(instance.erc20_2612Service, 'getNonce')
+        .mockReturnValue(Promise.resolve(null));
+
+      const signature: string = await instance.signStaking(
+        user,
+        amount,
+        deadline,
       );
+
+      expect(signature).toEqual('');
     });
   });
   describe('stakeWithPermit', () => {

--- a/packages/contract-helpers/src/staking-contract/staking.test.ts
+++ b/packages/contract-helpers/src/staking-contract/staking.test.ts
@@ -55,6 +55,7 @@ describe('StakingService', () => {
     });
   });
   describe('signStaking', () => {
+    const deadline = Math.floor(Date.now() / 1000 + 3600).toString();
     afterEach(() => {
       jest.clearAllMocks();
     });
@@ -83,7 +84,11 @@ describe('StakingService', () => {
         .spyOn(instance.erc20_2612Service, 'getNonce')
         .mockReturnValue(Promise.resolve(nonce));
 
-      const signature: string = await instance.signStaking(user, amount);
+      const signature: string = await instance.signStaking(
+        user,
+        amount,
+        deadline,
+      );
 
       expect(spy).toHaveBeenCalled();
 
@@ -97,18 +102,26 @@ describe('StakingService', () => {
       expect(message.spender).toEqual(STAKING_HELPER_ADDRESS);
       expect(message.nonce).toEqual(nonce);
       expect(message.value).toEqual(valueToWei(amount, decimals));
-      expect(message.deadline).toEqual(constants.MaxUint256.toString());
+      expect(message.deadline).toEqual(deadline);
     });
     it('Expects to fail when not initialized with TOKEN_STAKING_ADDRESS not address', async () => {
       const instance = new StakingService(provider, {
         TOKEN_STAKING_ADDRESS: 'asdf',
       });
-      const signature: string = await instance.signStaking(user, amount);
+      const signature: string = await instance.signStaking(
+        user,
+        amount,
+        deadline,
+      );
       expect(signature).toEqual([]);
     });
     it('Expects to fail when not initialized with STAKING_HELPER_ADDRESS', async () => {
       const instance = new StakingService(provider, { TOKEN_STAKING_ADDRESS });
-      const signature: string = await instance.signStaking(user, amount);
+      const signature: string = await instance.signStaking(
+        user,
+        amount,
+        deadline,
+      );
       expect(signature).toEqual([]);
     });
     it('Expects to fail when user not eth address', async () => {
@@ -118,7 +131,7 @@ describe('StakingService', () => {
       });
       const user = 'asdf';
       await expect(async () =>
-        instance.signStaking(user, amount),
+        instance.signStaking(user, amount, deadline),
       ).rejects.toThrowError(
         `Address: ${user} is not a valid ethereum Address`,
       );
@@ -130,7 +143,7 @@ describe('StakingService', () => {
       });
       const amount = '0';
       await expect(async () =>
-        instance.signStaking(user, amount),
+        instance.signStaking(user, amount, deadline),
       ).rejects.toThrowError(`Amount: ${amount} needs to be greater than 0`);
     });
     it('Expects to fail when amount not number', async () => {
@@ -140,7 +153,7 @@ describe('StakingService', () => {
       });
       const amount = 'asdf';
       await expect(async () =>
-        instance.signStaking(user, amount),
+        instance.signStaking(user, amount, deadline),
       ).rejects.toThrowError(`Amount: ${amount} needs to be greater than 0`);
     });
     it('Expects to fail when nonce not positive or 0', async () => {
@@ -150,7 +163,7 @@ describe('StakingService', () => {
       });
       const nonce = '-1';
       await expect(async () =>
-        instance.signStaking(user, amount),
+        instance.signStaking(user, amount, deadline),
       ).rejects.toThrowError(
         `Amount: ${nonce} needs to be greater or equal than 0`,
       );
@@ -162,7 +175,7 @@ describe('StakingService', () => {
       });
       const nonce = 'asdf';
       await expect(async () =>
-        instance.signStaking(user, amount),
+        instance.signStaking(user, amount, deadline),
       ).rejects.toThrowError(
         `Amount: ${nonce} needs to be greater or equal than 0`,
       );

--- a/packages/contract-helpers/src/staking-contract/staking.test.ts
+++ b/packages/contract-helpers/src/staking-contract/staking.test.ts
@@ -39,7 +39,6 @@ describe('StakingService', () => {
   const onBehalfOf = '0x0000000000000000000000000000000000000005';
 
   const amount = '123.456';
-  const nonce = '1';
   const decimals = 18;
 
   describe('Initialization', () => {
@@ -78,7 +77,13 @@ describe('StakingService', () => {
           Promise.resolve('0x0000000000000000000000000000000000000006'),
       } as unknown as IStakedToken);
 
-      const signature: string = await instance.signStaking(user, amount, nonce);
+      const nonce = '1';
+
+      jest
+        .spyOn(instance.erc20_2612Service, 'getNonce')
+        .mockReturnValue(Promise.resolve(Number(nonce)));
+
+      const signature: string = await instance.signStaking(user, amount);
 
       expect(spy).toHaveBeenCalled();
 
@@ -90,20 +95,20 @@ describe('StakingService', () => {
 
       expect(message.owner).toEqual(user);
       expect(message.spender).toEqual(STAKING_HELPER_ADDRESS);
-      expect(message.value).toEqual(valueToWei(amount, decimals));
       expect(message.nonce).toEqual(nonce);
+      expect(message.value).toEqual(valueToWei(amount, decimals));
       expect(message.deadline).toEqual(constants.MaxUint256.toString());
     });
     it('Expects to fail when not initialized with TOKEN_STAKING_ADDRESS not address', async () => {
       const instance = new StakingService(provider, {
         TOKEN_STAKING_ADDRESS: 'asdf',
       });
-      const signature: string = await instance.signStaking(user, amount, nonce);
+      const signature: string = await instance.signStaking(user, amount);
       expect(signature).toEqual([]);
     });
     it('Expects to fail when not initialized with STAKING_HELPER_ADDRESS', async () => {
       const instance = new StakingService(provider, { TOKEN_STAKING_ADDRESS });
-      const signature: string = await instance.signStaking(user, amount, nonce);
+      const signature: string = await instance.signStaking(user, amount);
       expect(signature).toEqual([]);
     });
     it('Expects to fail when user not eth address', async () => {
@@ -113,7 +118,7 @@ describe('StakingService', () => {
       });
       const user = 'asdf';
       await expect(async () =>
-        instance.signStaking(user, amount, nonce),
+        instance.signStaking(user, amount),
       ).rejects.toThrowError(
         `Address: ${user} is not a valid ethereum Address`,
       );
@@ -125,7 +130,7 @@ describe('StakingService', () => {
       });
       const amount = '0';
       await expect(async () =>
-        instance.signStaking(user, amount, nonce),
+        instance.signStaking(user, amount),
       ).rejects.toThrowError(`Amount: ${amount} needs to be greater than 0`);
     });
     it('Expects to fail when amount not number', async () => {
@@ -135,7 +140,7 @@ describe('StakingService', () => {
       });
       const amount = 'asdf';
       await expect(async () =>
-        instance.signStaking(user, amount, nonce),
+        instance.signStaking(user, amount),
       ).rejects.toThrowError(`Amount: ${amount} needs to be greater than 0`);
     });
     it('Expects to fail when nonce not positive or 0', async () => {
@@ -145,7 +150,7 @@ describe('StakingService', () => {
       });
       const nonce = '-1';
       await expect(async () =>
-        instance.signStaking(user, amount, nonce),
+        instance.signStaking(user, amount),
       ).rejects.toThrowError(
         `Amount: ${nonce} needs to be greater or equal than 0`,
       );
@@ -157,7 +162,7 @@ describe('StakingService', () => {
       });
       const nonce = 'asdf';
       await expect(async () =>
-        instance.signStaking(user, amount, nonce),
+        instance.signStaking(user, amount),
       ).rejects.toThrowError(
         `Amount: ${nonce} needs to be greater or equal than 0`,
       );

--- a/packages/contract-helpers/src/staking-contract/staking.test.ts
+++ b/packages/contract-helpers/src/staking-contract/staking.test.ts
@@ -55,7 +55,6 @@ describe('StakingService', () => {
     });
   });
   describe('signStaking', () => {
-    const deadline = Math.floor(Date.now() / 1000 + 3600).toString();
     afterEach(() => {
       jest.clearAllMocks();
     });
@@ -84,11 +83,7 @@ describe('StakingService', () => {
         .spyOn(instance.erc20_2612Service, 'getNonce')
         .mockReturnValue(Promise.resolve(nonce));
 
-      const signature: string = await instance.signStaking(
-        user,
-        amount,
-        deadline,
-      );
+      const signature: string = await instance.signStaking(user, amount);
 
       expect(spy).toHaveBeenCalled();
 
@@ -102,26 +97,18 @@ describe('StakingService', () => {
       expect(message.spender).toEqual(STAKING_HELPER_ADDRESS);
       expect(message.nonce).toEqual(nonce);
       expect(message.value).toEqual(valueToWei(amount, decimals));
-      expect(message.deadline).toEqual(deadline);
+      expect(message.deadline).toEqual(constants.MaxUint256.toString());
     });
     it('Expects to fail when not initialized with TOKEN_STAKING_ADDRESS not address', async () => {
       const instance = new StakingService(provider, {
         TOKEN_STAKING_ADDRESS: 'asdf',
       });
-      const signature: string = await instance.signStaking(
-        user,
-        amount,
-        deadline,
-      );
+      const signature: string = await instance.signStaking(user, amount);
       expect(signature).toEqual([]);
     });
     it('Expects to fail when not initialized with STAKING_HELPER_ADDRESS', async () => {
       const instance = new StakingService(provider, { TOKEN_STAKING_ADDRESS });
-      const signature: string = await instance.signStaking(
-        user,
-        amount,
-        deadline,
-      );
+      const signature: string = await instance.signStaking(user, amount);
       expect(signature).toEqual([]);
     });
     it('Expects to fail when user not eth address', async () => {
@@ -131,7 +118,7 @@ describe('StakingService', () => {
       });
       const user = 'asdf';
       await expect(async () =>
-        instance.signStaking(user, amount, deadline),
+        instance.signStaking(user, amount),
       ).rejects.toThrowError(
         `Address: ${user} is not a valid ethereum Address`,
       );
@@ -143,7 +130,7 @@ describe('StakingService', () => {
       });
       const amount = '0';
       await expect(async () =>
-        instance.signStaking(user, amount, deadline),
+        instance.signStaking(user, amount),
       ).rejects.toThrowError(`Amount: ${amount} needs to be greater than 0`);
     });
     it('Expects to fail when amount not number', async () => {
@@ -153,7 +140,7 @@ describe('StakingService', () => {
       });
       const amount = 'asdf';
       await expect(async () =>
-        instance.signStaking(user, amount, deadline),
+        instance.signStaking(user, amount),
       ).rejects.toThrowError(`Amount: ${amount} needs to be greater than 0`);
     });
     it('Expects the permission string to be `` when no nonce', async () => {
@@ -178,11 +165,7 @@ describe('StakingService', () => {
         .spyOn(instance.erc20_2612Service, 'getNonce')
         .mockReturnValue(Promise.resolve(null));
 
-      const signature: string = await instance.signStaking(
-        user,
-        amount,
-        deadline,
-      );
+      const signature: string = await instance.signStaking(user, amount);
 
       expect(signature).toEqual('');
     });

--- a/packages/contract-helpers/src/staking-contract/staking.test.ts
+++ b/packages/contract-helpers/src/staking-contract/staking.test.ts
@@ -77,11 +77,11 @@ describe('StakingService', () => {
           Promise.resolve('0x0000000000000000000000000000000000000006'),
       } as unknown as IStakedToken);
 
-      const nonce = '1';
+      const nonce = 1;
 
       jest
         .spyOn(instance.erc20_2612Service, 'getNonce')
-        .mockReturnValue(Promise.resolve(Number(nonce)));
+        .mockReturnValue(Promise.resolve(nonce));
 
       const signature: string = await instance.signStaking(user, amount);
 


### PR DESCRIPTION
- Removes nonce parameter from `signStake` and instead fetches token nonce automatically inside of signature method
- Adds default gas estimation for `stake` and `stakeWithPermit`