### PR TITLE
feat: add default gas estimation for borrow and vote

### DIFF
--- a/packages/contract-helpers/src/commons/types.ts
+++ b/packages/contract-helpers/src/commons/types.ts
@@ -96,6 +96,7 @@ export enum eEthereumTxType {
 export enum ProtocolAction {
   default = 'default',
   supply = 'supply',
+  borrow = 'borrow',
   withdraw = 'withdraw',
   deposit = 'deposit',
   liquidationCall = 'liquidationCall',

--- a/packages/contract-helpers/src/commons/types.ts
+++ b/packages/contract-helpers/src/commons/types.ts
@@ -109,6 +109,7 @@ export enum ProtocolAction {
   migrateV3 = 'migrateV3',
   supplyWithPermit = 'supplyWithPermit',
   repayWithPermit = 'repayWithPermit',
+  vote = 'vote',
 }
 
 export enum GovernanceVote {

--- a/packages/contract-helpers/src/commons/utils.ts
+++ b/packages/contract-helpers/src/commons/utils.ts
@@ -94,6 +94,10 @@ export const gasLimitRecommendations: GasRecommendationType = {
     limit: '350000',
     recommended: '350000',
   },
+  [ProtocolAction.vote]: {
+    limit: '125000',
+    recommended: '125000',
+  },
 };
 
 export const mintAmountsPerToken: Record<string, string> = {

--- a/packages/contract-helpers/src/commons/utils.ts
+++ b/packages/contract-helpers/src/commons/utils.ts
@@ -46,6 +46,10 @@ export const gasLimitRecommendations: GasRecommendationType = {
     limit: '300000',
     recommended: '300000',
   },
+  [ProtocolAction.borrow]: {
+    limit: '400000',
+    recommended: '400000',
+  },
   [ProtocolAction.withdraw]: {
     limit: '230000',
     recommended: '300000',

--- a/packages/contract-helpers/src/governance-contract/index.ts
+++ b/packages/contract-helpers/src/governance-contract/index.ts
@@ -4,6 +4,7 @@ import BaseService from '../commons/BaseService';
 import {
   eEthereumTxType,
   EthereumTransactionTypeExtended,
+  ProtocolAction,
   transactionType,
 } from '../commons/types';
 import {
@@ -119,7 +120,7 @@ export class AaveGovernanceService
     txs.push({
       tx: txCallback,
       txType: eEthereumTxType.GOVERNANCE_ACTION,
-      gas: this.generateTxPriceEstimation(txs, txCallback),
+      gas: this.generateTxPriceEstimation(txs, txCallback, ProtocolAction.vote),
     });
     return txs;
   }


### PR DESCRIPTION
Adds default estimate for borrow and vote which will sanity check that gas estimation will always return > this value

Borrow: 400k
Vote: 125k
Estimates come from gas limit analytics in Tenderly