### PR TITLE
fix: apply default gas limit estimations

### DIFF
--- a/packages/contract-helpers/src/governance-contract/governance.test.ts
+++ b/packages/contract-helpers/src/governance-contract/governance.test.ts
@@ -1,5 +1,11 @@
 import { BigNumber, providers, utils } from 'ethers';
-import { eEthereumTxType, GasType, transactionType } from '../commons/types';
+import {
+  eEthereumTxType,
+  GasType,
+  ProtocolAction,
+  transactionType,
+} from '../commons/types';
+import { gasLimitRecommendations } from '../commons/utils';
 import { IAaveGovernanceV2 } from './typechain/IAaveGovernanceV2';
 import { IAaveGovernanceV2__factory } from './typechain/IAaveGovernanceV2__factory';
 import { IGovernanceStrategy } from './typechain/IGovernanceStrategy';
@@ -153,7 +159,11 @@ describe('GovernanceService', () => {
       const tx: transactionType = await voteTxObj[0].tx();
       expect(tx.to).toEqual(GOVERNANCE_ADDRESS);
       expect(tx.from).toEqual(user);
-      expect(tx.gasLimit).toEqual(BigNumber.from(1));
+      expect(tx.gasLimit).toEqual(
+        BigNumber.from(
+          gasLimitRecommendations[ProtocolAction.vote].recommended,
+        ),
+      );
 
       const decoded = utils.defaultAbiCoder.decode(
         ['uint256', 'bool'],
@@ -166,7 +176,9 @@ describe('GovernanceService', () => {
       // gas price
       const gasPrice: GasType | null = await voteTxObj[0].gas();
       expect(gasPrice).not.toBeNull();
-      expect(gasPrice?.gasLimit).toEqual('1');
+      expect(gasPrice?.gasLimit).toEqual(
+        gasLimitRecommendations[ProtocolAction.vote].recommended,
+      );
       expect(gasPrice?.gasPrice).toEqual('1');
     });
     it('Expects to fail when gov address not eth address', () => {

--- a/packages/contract-helpers/src/governance-contract/index.ts
+++ b/packages/contract-helpers/src/governance-contract/index.ts
@@ -115,6 +115,7 @@ export class AaveGovernanceService
       rawTxMethod: async () =>
         govContract.populateTransaction.submitVote(proposalId, support),
       from: user,
+      action: ProtocolAction.vote,
     });
 
     txs.push({

--- a/packages/contract-helpers/src/lendingPool-contract/index.ts
+++ b/packages/contract-helpers/src/lendingPool-contract/index.ts
@@ -261,6 +261,7 @@ export class LendingPool
         ),
       from: user,
       value: getTxValue(reserve, convertedAmount),
+      action: ProtocolAction.deposit,
     });
 
     txs.push({
@@ -391,13 +392,18 @@ export class LendingPool
           onBehalfOf ?? user,
         ),
       from: user,
+      action: ProtocolAction.borrow,
     });
 
     return [
       {
         tx: txCallback,
         txType: eEthereumTxType.DLP_ACTION,
-        gas: this.generateTxPriceEstimation([], txCallback),
+        gas: this.generateTxPriceEstimation(
+          [],
+          txCallback,
+          ProtocolAction.borrow,
+        ),
       },
     ];
   }
@@ -475,6 +481,7 @@ export class LendingPool
         ),
       from: user,
       value: getTxValue(reserve, convertedAmount),
+      action: ProtocolAction.repay,
     });
 
     txs.push({
@@ -731,6 +738,7 @@ export class LendingPool
               referralCode ?? '0',
             ),
           from: user,
+          action: ProtocolAction.swapCollateral,
         });
 
       txs.push({
@@ -881,6 +889,7 @@ export class LendingPool
               referralCode ?? '0',
             ),
           from: user,
+          action: ProtocolAction.repayCollateral,
         });
 
       txs.push({
@@ -1045,6 +1054,7 @@ export class LendingPool
               referralCode ?? '0',
             ),
           from: user,
+          action: ProtocolAction.repayCollateral,
         });
 
       txs.push({

--- a/packages/contract-helpers/src/lendingPool-contract/lendingPool.test.ts
+++ b/packages/contract-helpers/src/lendingPool-contract/lendingPool.test.ts
@@ -115,7 +115,11 @@ describe('LendingPool', () => {
       const tx: transactionType = await txObj.tx();
       expect(tx.to).toEqual(LENDING_POOL);
       expect(tx.from).toEqual(user);
-      expect(tx.gasLimit).toEqual(BigNumber.from(1));
+      expect(tx.gasLimit).toEqual(
+        BigNumber.from(
+          gasLimitRecommendations[ProtocolAction.deposit].recommended,
+        ),
+      );
       expect(tx.value).toEqual(DEFAULT_NULL_VALUE_ON_TX);
 
       const decoded = utils.defaultAbiCoder.decode(
@@ -131,8 +135,10 @@ describe('LendingPool', () => {
       // gas price
       const gasPrice: GasType | null = await txObj.gas();
       expect(gasPrice).not.toBeNull();
-      expect(gasPrice?.gasLimit).toEqual('1');
       expect(gasPrice?.gasPrice).toEqual('1');
+      expect(gasPrice?.gasLimit).toEqual(
+        gasLimitRecommendations[ProtocolAction.deposit].recommended,
+      );
     });
     it('Expects the tx object passing all parameters but not onBehalfOf', async () => {
       const lendingPoolInstance = new LendingPool(provider, config);
@@ -164,7 +170,11 @@ describe('LendingPool', () => {
       const tx: transactionType = await txObj.tx();
       expect(tx.to).toEqual(LENDING_POOL);
       expect(tx.from).toEqual(user);
-      expect(tx.gasLimit).toEqual(BigNumber.from(1));
+      expect(tx.gasLimit).toEqual(
+        BigNumber.from(
+          gasLimitRecommendations[ProtocolAction.deposit].recommended,
+        ),
+      );
       expect(tx.value).toEqual(DEFAULT_NULL_VALUE_ON_TX);
 
       const decoded = utils.defaultAbiCoder.decode(
@@ -180,8 +190,10 @@ describe('LendingPool', () => {
       // gas price
       const gasPrice: GasType | null = await txObj.gas();
       expect(gasPrice).not.toBeNull();
-      expect(gasPrice?.gasLimit).toEqual('1');
       expect(gasPrice?.gasPrice).toEqual('1');
+      expect(gasPrice?.gasLimit).toEqual(
+        gasLimitRecommendations[ProtocolAction.deposit].recommended,
+      );
     });
     it('Expects the tx object passing all parameters but not referral', async () => {
       const lendingPoolInstance = new LendingPool(provider, config);
@@ -213,7 +225,11 @@ describe('LendingPool', () => {
       const tx: transactionType = await txObj.tx();
       expect(tx.to).toEqual(LENDING_POOL);
       expect(tx.from).toEqual(user);
-      expect(tx.gasLimit).toEqual(BigNumber.from(1));
+      expect(tx.gasLimit).toEqual(
+        BigNumber.from(
+          gasLimitRecommendations[ProtocolAction.deposit].recommended,
+        ),
+      );
       expect(tx.value).toEqual(DEFAULT_NULL_VALUE_ON_TX);
 
       const decoded = utils.defaultAbiCoder.decode(
@@ -229,8 +245,10 @@ describe('LendingPool', () => {
       // gas price
       const gasPrice: GasType | null = await txObj.gas();
       expect(gasPrice).not.toBeNull();
-      expect(gasPrice?.gasLimit).toEqual('1');
       expect(gasPrice?.gasPrice).toEqual('1');
+      expect(gasPrice?.gasLimit).toEqual(
+        gasLimitRecommendations[ProtocolAction.deposit].recommended,
+      );
     });
     it('Expects the tx object passing all parameters and needing approval', async () => {
       const lendingPoolInstance = new LendingPool(provider, config);
@@ -274,7 +292,11 @@ describe('LendingPool', () => {
       const tx: transactionType = await txObj.tx();
       expect(tx.to).toEqual(LENDING_POOL);
       expect(tx.from).toEqual(user);
-      expect(tx.gasLimit).toEqual(BigNumber.from(1));
+      expect(tx.gasLimit).toEqual(
+        BigNumber.from(
+          gasLimitRecommendations[ProtocolAction.deposit].recommended,
+        ),
+      );
       expect(tx.value).toEqual(DEFAULT_NULL_VALUE_ON_TX);
 
       const decoded = utils.defaultAbiCoder.decode(
@@ -291,7 +313,9 @@ describe('LendingPool', () => {
       const gasPrice: GasType | null = await txObj.gas();
       expect(gasPrice).not.toBeNull();
       expect(gasPrice?.gasLimit).toEqual('300000');
-      expect(gasPrice?.gasPrice).toEqual('1');
+      expect(gasPrice?.gasLimit).toEqual(
+        gasLimitRecommendations[ProtocolAction.deposit].recommended,
+      );
     });
     it('Expects to fail when passing all params and depositing Synthetix but amount not valid', async () => {
       const lendingPoolInstance = new LendingPool(provider, config);
@@ -470,7 +494,9 @@ describe('LendingPool', () => {
       expect(gasPrice?.gasLimit).toEqual(
         gasLimitRecommendations[ProtocolAction.withdraw].recommended,
       );
-      expect(gasPrice?.gasPrice).toEqual('1');
+      expect(gasPrice?.gasLimit).toEqual(
+        gasLimitRecommendations[ProtocolAction.withdraw].recommended,
+      );
     });
     it('Expects the tx object passing all params and -1 amount', async () => {
       const lendingPoolInstance = new LendingPool(provider, config);
@@ -516,7 +542,9 @@ describe('LendingPool', () => {
       expect(gasPrice?.gasLimit).toEqual(
         gasLimitRecommendations[ProtocolAction.withdraw].recommended,
       );
-      expect(gasPrice?.gasPrice).toEqual('1');
+      expect(gasPrice?.gasLimit).toEqual(
+        gasLimitRecommendations[ProtocolAction.withdraw].recommended,
+      );
     });
     it('Expects to fail for eth withdraw if not aTokenAddress is passed', async () => {
       const reserve = API_ETH_MOCK_ADDRESS;
@@ -687,7 +715,11 @@ describe('LendingPool', () => {
       const tx: transactionType = await txObj.tx();
       expect(tx.to).toEqual(LENDING_POOL);
       expect(tx.from).toEqual(user);
-      expect(tx.gasLimit).toEqual(BigNumber.from(1));
+      expect(tx.gasLimit).toEqual(
+        BigNumber.from(
+          gasLimitRecommendations[ProtocolAction.borrow].recommended,
+        ),
+      );
 
       const decoded = utils.defaultAbiCoder.decode(
         ['address', 'uint256', 'uint256', 'uint16', 'address'],
@@ -703,8 +735,10 @@ describe('LendingPool', () => {
       // gas price
       const gasPrice: GasType | null = await txObj.gas();
       expect(gasPrice).not.toBeNull();
-      expect(gasPrice?.gasLimit).toEqual('1');
       expect(gasPrice?.gasPrice).toEqual('1');
+      expect(gasPrice?.gasLimit).toEqual(
+        gasLimitRecommendations[ProtocolAction.borrow].recommended,
+      );
     });
     it('Expects the tx object passing all parameters but not referralCode and rate stable', async () => {
       const lendingPoolInstance = new LendingPool(provider, config);
@@ -731,7 +765,11 @@ describe('LendingPool', () => {
       const tx: transactionType = await txObj.tx();
       expect(tx.to).toEqual(LENDING_POOL);
       expect(tx.from).toEqual(user);
-      expect(tx.gasLimit).toEqual(BigNumber.from(1));
+      expect(tx.gasLimit).toEqual(
+        BigNumber.from(
+          gasLimitRecommendations[ProtocolAction.borrow].recommended,
+        ),
+      );
 
       const decoded = utils.defaultAbiCoder.decode(
         ['address', 'uint256', 'uint256', 'uint16', 'address'],
@@ -747,8 +785,10 @@ describe('LendingPool', () => {
       // gas price
       const gasPrice: GasType | null = await txObj.gas();
       expect(gasPrice).not.toBeNull();
-      expect(gasPrice?.gasLimit).toEqual('1');
       expect(gasPrice?.gasPrice).toEqual('1');
+      expect(gasPrice?.gasLimit).toEqual(
+        gasLimitRecommendations[ProtocolAction.borrow].recommended,
+      );
     });
     it('Expects the tx object passing all parameters with Interest rate Variable', async () => {
       const lendingPoolInstance = new LendingPool(provider, config);
@@ -775,7 +815,11 @@ describe('LendingPool', () => {
       const tx: transactionType = await txObj.tx();
       expect(tx.to).toEqual(LENDING_POOL);
       expect(tx.from).toEqual(user);
-      expect(tx.gasLimit).toEqual(BigNumber.from(1));
+      expect(tx.gasLimit).toEqual(
+        BigNumber.from(
+          gasLimitRecommendations[ProtocolAction.borrow].recommended,
+        ),
+      );
 
       const decoded = utils.defaultAbiCoder.decode(
         ['address', 'uint256', 'uint256', 'uint16', 'address'],
@@ -791,8 +835,10 @@ describe('LendingPool', () => {
       // gas price
       const gasPrice: GasType | null = await txObj.gas();
       expect(gasPrice).not.toBeNull();
-      expect(gasPrice?.gasLimit).toEqual('1');
       expect(gasPrice?.gasPrice).toEqual('1');
+      expect(gasPrice?.gasLimit).toEqual(
+        gasLimitRecommendations[ProtocolAction.borrow].recommended,
+      );
     });
     it('Expects to fail when borrowing eth and not passing debtTokenAddress', async () => {
       const reserve = API_ETH_MOCK_ADDRESS;
@@ -982,7 +1028,11 @@ describe('LendingPool', () => {
       const tx: transactionType = await txObj.tx();
       expect(tx.to).toEqual(LENDING_POOL);
       expect(tx.from).toEqual(user);
-      expect(tx.gasLimit).toEqual(BigNumber.from(1));
+      expect(tx.gasLimit).toEqual(
+        BigNumber.from(
+          gasLimitRecommendations[ProtocolAction.repay].recommended,
+        ),
+      );
       expect(tx.value).toEqual(DEFAULT_NULL_VALUE_ON_TX);
 
       const decoded = utils.defaultAbiCoder.decode(
@@ -998,8 +1048,10 @@ describe('LendingPool', () => {
       // gas price
       const gasPrice: GasType | null = await txObj.gas();
       expect(gasPrice).not.toBeNull();
-      expect(gasPrice?.gasLimit).toEqual('1');
       expect(gasPrice?.gasPrice).toEqual('1');
+      expect(gasPrice?.gasLimit).toEqual(
+        gasLimitRecommendations[ProtocolAction.repay].recommended,
+      );
     });
     it('Expects the tx object passing all params with amount -1 with approve needed and reate stable', async () => {
       const lendingPoolInstance = new LendingPool(provider, config);
@@ -1045,7 +1097,11 @@ describe('LendingPool', () => {
       const tx: transactionType = await txObj.tx();
       expect(tx.to).toEqual(LENDING_POOL);
       expect(tx.from).toEqual(user);
-      expect(tx.gasLimit).toEqual(BigNumber.from(1));
+      expect(tx.gasLimit).toEqual(
+        BigNumber.from(
+          gasLimitRecommendations[ProtocolAction.repay].recommended,
+        ),
+      );
       expect(tx.value).toEqual(DEFAULT_NULL_VALUE_ON_TX);
 
       const decoded = utils.defaultAbiCoder.decode(
@@ -1064,7 +1120,9 @@ describe('LendingPool', () => {
       expect(gasPrice?.gasLimit).toEqual(
         gasLimitRecommendations[ProtocolAction.repay].limit,
       );
-      expect(gasPrice?.gasPrice).toEqual('1');
+      expect(gasPrice?.gasLimit).toEqual(
+        gasLimitRecommendations[ProtocolAction.repay].recommended,
+      );
     });
     it('Expects the tx object passing all params with with specific amount and synthetix repayment with valid amount and rate variable', async () => {
       const lendingPoolInstance = new LendingPool(provider, config);
@@ -1109,7 +1167,11 @@ describe('LendingPool', () => {
       const tx: transactionType = await txObj.tx();
       expect(tx.to).toEqual(LENDING_POOL);
       expect(tx.from).toEqual(user);
-      expect(tx.gasLimit).toEqual(BigNumber.from(1));
+      expect(tx.gasLimit).toEqual(
+        BigNumber.from(
+          gasLimitRecommendations[ProtocolAction.repay].recommended,
+        ),
+      );
       expect(tx.value).toEqual(DEFAULT_NULL_VALUE_ON_TX);
 
       const decoded = utils.defaultAbiCoder.decode(
@@ -1128,7 +1190,9 @@ describe('LendingPool', () => {
       expect(gasPrice?.gasLimit).toEqual(
         gasLimitRecommendations[ProtocolAction.repay].limit,
       );
-      expect(gasPrice?.gasPrice).toEqual('1');
+      expect(gasPrice?.gasLimit).toEqual(
+        gasLimitRecommendations[ProtocolAction.repay].recommended,
+      );
     });
     it('Expects to fail passing all params with with specific amount and synthetix repayment but not valid amount', async () => {
       const lendingPoolInstance = new LendingPool(provider, config);
@@ -1849,7 +1913,11 @@ describe('LendingPool', () => {
       const tx: transactionType = await txObj.tx();
       expect(tx.to).toEqual(LENDING_POOL);
       expect(tx.from).toEqual(user);
-      expect(tx.gasLimit).toEqual(BigNumber.from(1));
+      expect(tx.gasLimit).toEqual(
+        BigNumber.from(
+          gasLimitRecommendations[ProtocolAction.swapCollateral].recommended,
+        ),
+      );
       expect(tx.value).toEqual(DEFAULT_NULL_VALUE_ON_TX);
 
       const decoded = utils.defaultAbiCoder.decode(
@@ -1906,7 +1974,9 @@ describe('LendingPool', () => {
       expect(gasPrice?.gasLimit).toEqual(
         gasLimitRecommendations[ProtocolAction.swapCollateral].limit,
       );
-      expect(gasPrice?.gasPrice).toEqual('1');
+      expect(gasPrice?.gasLimit).toEqual(
+        gasLimitRecommendations[ProtocolAction.swapCollateral].recommended,
+      );
     });
     it('Expects the tx object passing all params without onBehalf and no approval needed for flash', async () => {
       const lendingPoolInstance = new LendingPool(provider, config);
@@ -1943,7 +2013,11 @@ describe('LendingPool', () => {
       const tx: transactionType = await txObj.tx();
       expect(tx.to).toEqual(LENDING_POOL);
       expect(tx.from).toEqual(user);
-      expect(tx.gasLimit).toEqual(BigNumber.from(1));
+      expect(tx.gasLimit).toEqual(
+        BigNumber.from(
+          gasLimitRecommendations[ProtocolAction.swapCollateral].recommended,
+        ),
+      );
       expect(tx.value).toEqual(DEFAULT_NULL_VALUE_ON_TX);
 
       const decoded = utils.defaultAbiCoder.decode(
@@ -1997,8 +2071,10 @@ describe('LendingPool', () => {
       // gas price
       const gasPrice: GasType | null = await txObj.gas();
       expect(gasPrice).not.toBeNull();
-      expect(gasPrice?.gasLimit).toEqual('1');
       expect(gasPrice?.gasPrice).toEqual('1');
+      expect(gasPrice?.gasLimit).toEqual(
+        gasLimitRecommendations[ProtocolAction.swapCollateral].recommended,
+      );
     });
     it('Expects the tx object passing all params without referralCode and no approval needed for flash', async () => {
       const lendingPoolInstance = new LendingPool(provider, config);
@@ -2035,7 +2111,11 @@ describe('LendingPool', () => {
       const tx: transactionType = await txObj.tx();
       expect(tx.to).toEqual(LENDING_POOL);
       expect(tx.from).toEqual(user);
-      expect(tx.gasLimit).toEqual(BigNumber.from(1));
+      expect(tx.gasLimit).toEqual(
+        BigNumber.from(
+          gasLimitRecommendations[ProtocolAction.swapCollateral].recommended,
+        ),
+      );
       expect(tx.value).toEqual(DEFAULT_NULL_VALUE_ON_TX);
 
       const decoded = utils.defaultAbiCoder.decode(
@@ -2089,8 +2169,10 @@ describe('LendingPool', () => {
       // gas price
       const gasPrice: GasType | null = await txObj.gas();
       expect(gasPrice).not.toBeNull();
-      expect(gasPrice?.gasLimit).toEqual('1');
       expect(gasPrice?.gasPrice).toEqual('1');
+      expect(gasPrice?.gasLimit).toEqual(
+        gasLimitRecommendations[ProtocolAction.swapCollateral].recommended,
+      );
     });
     it('Expects the tx object passing all params and no approval needed with flash and no swapAll', async () => {
       const lendingPoolInstance = new LendingPool(provider, config);
@@ -2128,7 +2210,11 @@ describe('LendingPool', () => {
       const tx: transactionType = await txObj.tx();
       expect(tx.to).toEqual(LENDING_POOL);
       expect(tx.from).toEqual(user);
-      expect(tx.gasLimit).toEqual(BigNumber.from(1));
+      expect(tx.gasLimit).toEqual(
+        BigNumber.from(
+          gasLimitRecommendations[ProtocolAction.swapCollateral].recommended,
+        ),
+      );
       expect(tx.value).toEqual(DEFAULT_NULL_VALUE_ON_TX);
 
       const decoded = utils.defaultAbiCoder.decode(
@@ -2182,8 +2268,10 @@ describe('LendingPool', () => {
       // gas price
       const gasPrice: GasType | null = await txObj.gas();
       expect(gasPrice).not.toBeNull();
-      expect(gasPrice?.gasLimit).toEqual('1');
       expect(gasPrice?.gasPrice).toEqual('1');
+      expect(gasPrice?.gasLimit).toEqual(
+        gasLimitRecommendations[ProtocolAction.swapCollateral].recommended,
+      );
     });
     it('Expects the tx object passing all params without permitSignature and no approval needed without flash', async () => {
       const lendingPoolInstance = new LendingPool(provider, config);
@@ -2571,7 +2659,11 @@ describe('LendingPool', () => {
       const tx: transactionType = await txObj.tx();
       expect(tx.to).toEqual(LENDING_POOL);
       expect(tx.from).toEqual(user);
-      expect(tx.gasLimit).toEqual(BigNumber.from(1));
+      expect(tx.gasLimit).toEqual(
+        BigNumber.from(
+          gasLimitRecommendations[ProtocolAction.repayCollateral].recommended,
+        ),
+      );
       expect(tx.value).toEqual(DEFAULT_NULL_VALUE_ON_TX);
 
       const decoded = utils.defaultAbiCoder.decode(
@@ -2628,7 +2720,9 @@ describe('LendingPool', () => {
       expect(gasPrice?.gasLimit).toEqual(
         gasLimitRecommendations[ProtocolAction.repayCollateral].limit,
       );
-      expect(gasPrice?.gasPrice).toEqual('1');
+      expect(gasPrice?.gasLimit).toEqual(
+        gasLimitRecommendations[ProtocolAction.repayCollateral].recommended,
+      );
     });
     it('Expects the tx object passing all params and no approval needed for flash with rate mode Stable', async () => {
       const lendingPoolInstance = new LendingPool(provider, config);
@@ -2667,7 +2761,11 @@ describe('LendingPool', () => {
       const tx: transactionType = await txObj.tx();
       expect(tx.to).toEqual(LENDING_POOL);
       expect(tx.from).toEqual(user);
-      expect(tx.gasLimit).toEqual(BigNumber.from(1));
+      expect(tx.gasLimit).toEqual(
+        BigNumber.from(
+          gasLimitRecommendations[ProtocolAction.repayCollateral].recommended,
+        ),
+      );
       expect(tx.value).toEqual(DEFAULT_NULL_VALUE_ON_TX);
 
       const decoded = utils.defaultAbiCoder.decode(
@@ -2721,8 +2819,10 @@ describe('LendingPool', () => {
       // gas price
       const gasPrice: GasType | null = await txObj.gas();
       expect(gasPrice).not.toBeNull();
-      expect(gasPrice?.gasLimit).toEqual('1');
       expect(gasPrice?.gasPrice).toEqual('1');
+      expect(gasPrice?.gasLimit).toEqual(
+        gasLimitRecommendations[ProtocolAction.repayCollateral].recommended,
+      );
     });
     it('Expects the tx object passing all params and no approval needed for flash with rate mode Variable', async () => {
       const lendingPoolInstance = new LendingPool(provider, config);
@@ -2761,7 +2861,11 @@ describe('LendingPool', () => {
       const tx: transactionType = await txObj.tx();
       expect(tx.to).toEqual(LENDING_POOL);
       expect(tx.from).toEqual(user);
-      expect(tx.gasLimit).toEqual(BigNumber.from(1));
+      expect(tx.gasLimit).toEqual(
+        BigNumber.from(
+          gasLimitRecommendations[ProtocolAction.repayCollateral].recommended,
+        ),
+      );
       expect(tx.value).toEqual(DEFAULT_NULL_VALUE_ON_TX);
 
       const decoded = utils.defaultAbiCoder.decode(
@@ -2815,8 +2919,10 @@ describe('LendingPool', () => {
       // gas price
       const gasPrice: GasType | null = await txObj.gas();
       expect(gasPrice).not.toBeNull();
-      expect(gasPrice?.gasLimit).toEqual('1');
       expect(gasPrice?.gasPrice).toEqual('1');
+      expect(gasPrice?.gasLimit).toEqual(
+        gasLimitRecommendations[ProtocolAction.repayCollateral].recommended,
+      );
     });
     it('Expects the tx object passing all params and no approval needed for flash without onBehalfOf', async () => {
       const lendingPoolInstance = new LendingPool(provider, config);
@@ -2854,7 +2960,11 @@ describe('LendingPool', () => {
       const tx: transactionType = await txObj.tx();
       expect(tx.to).toEqual(LENDING_POOL);
       expect(tx.from).toEqual(user);
-      expect(tx.gasLimit).toEqual(BigNumber.from(1));
+      expect(tx.gasLimit).toEqual(
+        BigNumber.from(
+          gasLimitRecommendations[ProtocolAction.repayCollateral].recommended,
+        ),
+      );
       expect(tx.value).toEqual(DEFAULT_NULL_VALUE_ON_TX);
 
       const decoded = utils.defaultAbiCoder.decode(
@@ -2908,8 +3018,10 @@ describe('LendingPool', () => {
       // gas price
       const gasPrice: GasType | null = await txObj.gas();
       expect(gasPrice).not.toBeNull();
-      expect(gasPrice?.gasLimit).toEqual('1');
       expect(gasPrice?.gasPrice).toEqual('1');
+      expect(gasPrice?.gasLimit).toEqual(
+        gasLimitRecommendations[ProtocolAction.repayCollateral].recommended,
+      );
     });
     it('Expects the tx object passing all params and no approval needed for flash without referralCode', async () => {
       const lendingPoolInstance = new LendingPool(provider, config);
@@ -2947,7 +3059,11 @@ describe('LendingPool', () => {
       const tx: transactionType = await txObj.tx();
       expect(tx.to).toEqual(LENDING_POOL);
       expect(tx.from).toEqual(user);
-      expect(tx.gasLimit).toEqual(BigNumber.from(1));
+      expect(tx.gasLimit).toEqual(
+        BigNumber.from(
+          gasLimitRecommendations[ProtocolAction.repayCollateral].recommended,
+        ),
+      );
       expect(tx.value).toEqual(DEFAULT_NULL_VALUE_ON_TX);
 
       const decoded = utils.defaultAbiCoder.decode(
@@ -3001,8 +3117,10 @@ describe('LendingPool', () => {
       // gas price
       const gasPrice: GasType | null = await txObj.gas();
       expect(gasPrice).not.toBeNull();
-      expect(gasPrice?.gasLimit).toEqual('1');
       expect(gasPrice?.gasPrice).toEqual('1');
+      expect(gasPrice?.gasLimit).toEqual(
+        gasLimitRecommendations[ProtocolAction.repayCollateral].recommended,
+      );
     });
     it('Expects the tx object passing all params and no approval needed for flash without useEthPath', async () => {
       const lendingPoolInstance = new LendingPool(provider, config);
@@ -3040,7 +3158,11 @@ describe('LendingPool', () => {
       const tx: transactionType = await txObj.tx();
       expect(tx.to).toEqual(LENDING_POOL);
       expect(tx.from).toEqual(user);
-      expect(tx.gasLimit).toEqual(BigNumber.from(1));
+      expect(tx.gasLimit).toEqual(
+        BigNumber.from(
+          gasLimitRecommendations[ProtocolAction.repayCollateral].recommended,
+        ),
+      );
       expect(tx.value).toEqual(DEFAULT_NULL_VALUE_ON_TX);
 
       const decoded = utils.defaultAbiCoder.decode(
@@ -3094,8 +3216,10 @@ describe('LendingPool', () => {
       // gas price
       const gasPrice: GasType | null = await txObj.gas();
       expect(gasPrice).not.toBeNull();
-      expect(gasPrice?.gasLimit).toEqual('1');
       expect(gasPrice?.gasPrice).toEqual('1');
+      expect(gasPrice?.gasLimit).toEqual(
+        gasLimitRecommendations[ProtocolAction.repayCollateral].recommended,
+      );
     });
     it('Expects the tx object passing all params and no approval needed without flash and not repayAllDebt', async () => {
       const lendingPoolInstance = new LendingPool(provider, config);
@@ -3133,7 +3257,11 @@ describe('LendingPool', () => {
       const tx: transactionType = await txObj.tx();
       expect(tx.to).toEqual(LENDING_POOL);
       expect(tx.from).toEqual(user);
-      expect(tx.gasLimit).toEqual(BigNumber.from(1));
+      expect(tx.gasLimit).toEqual(
+        BigNumber.from(
+          gasLimitRecommendations[ProtocolAction.repayCollateral].recommended,
+        ),
+      );
       expect(tx.value).toEqual(DEFAULT_NULL_VALUE_ON_TX);
 
       const decoded = utils.defaultAbiCoder.decode(
@@ -3187,8 +3315,10 @@ describe('LendingPool', () => {
       // gas price
       const gasPrice: GasType | null = await txObj.gas();
       expect(gasPrice).not.toBeNull();
-      expect(gasPrice?.gasLimit).toEqual('1');
       expect(gasPrice?.gasPrice).toEqual('1');
+      expect(gasPrice?.gasLimit).toEqual(
+        gasLimitRecommendations[ProtocolAction.repayCollateral].recommended,
+      );
     });
     it('Expects the tx object passing all params and no permitSignature, and no flash', async () => {
       const lendingPoolInstance = new LendingPool(provider, config);
@@ -3916,7 +4046,11 @@ describe('LendingPool', () => {
       const tx: transactionType = await txObj.tx();
       expect(tx.to).toEqual(LENDING_POOL);
       expect(tx.from).toEqual(user);
-      expect(tx.gasLimit).toEqual(BigNumber.from(1));
+      expect(tx.gasLimit).toEqual(
+        BigNumber.from(
+          gasLimitRecommendations[ProtocolAction.repayCollateral].recommended,
+        ),
+      );
       expect(tx.value).toEqual(DEFAULT_NULL_VALUE_ON_TX);
 
       const decoded = utils.defaultAbiCoder.decode(
@@ -4015,7 +4149,11 @@ describe('LendingPool', () => {
       const tx: transactionType = await txObj.tx();
       expect(tx.to).toEqual(LENDING_POOL);
       expect(tx.from).toEqual(user);
-      expect(tx.gasLimit).toEqual(BigNumber.from(1));
+      expect(tx.gasLimit).toEqual(
+        BigNumber.from(
+          gasLimitRecommendations[ProtocolAction.repayCollateral].recommended,
+        ),
+      );
       expect(tx.value).toEqual(DEFAULT_NULL_VALUE_ON_TX);
 
       const decoded = utils.defaultAbiCoder.decode(
@@ -4071,7 +4209,9 @@ describe('LendingPool', () => {
       // gas price
       const gasPrice: GasType | null = await txObj.gas();
       expect(gasPrice).not.toBeNull();
-      expect(gasPrice?.gasLimit).toEqual('1');
+      expect(gasPrice?.gasLimit).toEqual(
+        gasLimitRecommendations[ProtocolAction.repayCollateral].recommended,
+      );
       expect(gasPrice?.gasPrice).toEqual('1');
     });
     it('Expects the tx object passing all params and no approval needed for flash with rate mode Variable', async () => {
@@ -4112,7 +4252,11 @@ describe('LendingPool', () => {
       const tx: transactionType = await txObj.tx();
       expect(tx.to).toEqual(LENDING_POOL);
       expect(tx.from).toEqual(user);
-      expect(tx.gasLimit).toEqual(BigNumber.from(1));
+      expect(tx.gasLimit).toEqual(
+        BigNumber.from(
+          gasLimitRecommendations[ProtocolAction.repayCollateral].recommended,
+        ),
+      );
       expect(tx.value).toEqual(DEFAULT_NULL_VALUE_ON_TX);
 
       const decoded = utils.defaultAbiCoder.decode(
@@ -4168,7 +4312,9 @@ describe('LendingPool', () => {
       // gas price
       const gasPrice: GasType | null = await txObj.gas();
       expect(gasPrice).not.toBeNull();
-      expect(gasPrice?.gasLimit).toEqual('1');
+      expect(gasPrice?.gasLimit).toEqual(
+        gasLimitRecommendations[ProtocolAction.repayCollateral].recommended,
+      );
       expect(gasPrice?.gasPrice).toEqual('1');
     });
     it('Expects the tx object passing all params and no approval needed for flash without onBehalfOf', async () => {
@@ -4208,7 +4354,11 @@ describe('LendingPool', () => {
       const tx: transactionType = await txObj.tx();
       expect(tx.to).toEqual(LENDING_POOL);
       expect(tx.from).toEqual(user);
-      expect(tx.gasLimit).toEqual(BigNumber.from(1));
+      expect(tx.gasLimit).toEqual(
+        BigNumber.from(
+          gasLimitRecommendations[ProtocolAction.repayCollateral].recommended,
+        ),
+      );
       expect(tx.value).toEqual(DEFAULT_NULL_VALUE_ON_TX);
 
       const decoded = utils.defaultAbiCoder.decode(
@@ -4264,7 +4414,9 @@ describe('LendingPool', () => {
       // gas price
       const gasPrice: GasType | null = await txObj.gas();
       expect(gasPrice).not.toBeNull();
-      expect(gasPrice?.gasLimit).toEqual('1');
+      expect(gasPrice?.gasLimit).toEqual(
+        gasLimitRecommendations[ProtocolAction.repayCollateral].recommended,
+      );
       expect(gasPrice?.gasPrice).toEqual('1');
     });
     it('Expects the tx object passing all params and no approval needed for flash without referralCode', async () => {
@@ -4304,7 +4456,11 @@ describe('LendingPool', () => {
       const tx: transactionType = await txObj.tx();
       expect(tx.to).toEqual(LENDING_POOL);
       expect(tx.from).toEqual(user);
-      expect(tx.gasLimit).toEqual(BigNumber.from(1));
+      expect(tx.gasLimit).toEqual(
+        BigNumber.from(
+          gasLimitRecommendations[ProtocolAction.repayCollateral].recommended,
+        ),
+      );
       expect(tx.value).toEqual(DEFAULT_NULL_VALUE_ON_TX);
 
       const decoded = utils.defaultAbiCoder.decode(
@@ -4360,8 +4516,10 @@ describe('LendingPool', () => {
       // gas price
       const gasPrice: GasType | null = await txObj.gas();
       expect(gasPrice).not.toBeNull();
-      expect(gasPrice?.gasLimit).toEqual('1');
       expect(gasPrice?.gasPrice).toEqual('1');
+      expect(gasPrice?.gasLimit).toEqual(
+        gasLimitRecommendations[ProtocolAction.repayCollateral].recommended,
+      );
     });
     it('Expects the tx object passing all params and no approval needed without flash and not repayAllDebt', async () => {
       const poolInstance = new LendingPool(provider, config);
@@ -4400,7 +4558,11 @@ describe('LendingPool', () => {
       const tx: transactionType = await txObj.tx();
       expect(tx.to).toEqual(LENDING_POOL);
       expect(tx.from).toEqual(user);
-      expect(tx.gasLimit).toEqual(BigNumber.from(1));
+      expect(tx.gasLimit).toEqual(
+        BigNumber.from(
+          gasLimitRecommendations[ProtocolAction.repayCollateral].recommended,
+        ),
+      );
       expect(tx.value).toEqual(DEFAULT_NULL_VALUE_ON_TX);
 
       const decoded = utils.defaultAbiCoder.decode(
@@ -4456,8 +4618,10 @@ describe('LendingPool', () => {
       // gas price
       const gasPrice: GasType | null = await txObj.gas();
       expect(gasPrice).not.toBeNull();
-      expect(gasPrice?.gasLimit).toEqual('1');
       expect(gasPrice?.gasPrice).toEqual('1');
+      expect(gasPrice?.gasLimit).toEqual(
+        gasLimitRecommendations[ProtocolAction.repayCollateral].recommended,
+      );
     });
     it('Expects the tx object passing all params and no permitSignature, and no flash', async () => {
       const poolInstance = new LendingPool(provider, config);

--- a/packages/contract-helpers/src/v3-pool-contract/index.ts
+++ b/packages/contract-helpers/src/v3-pool-contract/index.ts
@@ -299,6 +299,7 @@ export class Pool extends BaseService<IPool> implements PoolInterface {
         ),
       from: user,
       value: getTxValue(reserve, convertedAmount),
+      action: ProtocolAction.supply,
     });
 
     txs.push({
@@ -394,6 +395,7 @@ export class Pool extends BaseService<IPool> implements PoolInterface {
         ),
       from: user,
       value: getTxValue(reserve, convertedAmount),
+      action: ProtocolAction.supply,
     });
 
     txs.push({
@@ -545,12 +547,17 @@ export class Pool extends BaseService<IPool> implements PoolInterface {
           sig.s,
         ),
       from: user,
+      action: ProtocolAction.supplyWithPermit,
     });
 
     txs.push({
       tx: txCallback,
       txType: eEthereumTxType.DLP_ACTION,
-      gas: this.generateTxPriceEstimation(txs, txCallback),
+      gas: this.generateTxPriceEstimation(
+        txs,
+        txCallback,
+        ProtocolAction.supplyWithPermit,
+      ),
     });
 
     return txs;
@@ -693,13 +700,18 @@ export class Pool extends BaseService<IPool> implements PoolInterface {
           onBehalfOf ?? user,
         ),
       from: user,
+      action: ProtocolAction.borrow,
     });
 
     return [
       {
         tx: txCallback,
         txType: eEthereumTxType.DLP_ACTION,
-        gas: this.generateTxPriceEstimation([], txCallback),
+        gas: this.generateTxPriceEstimation(
+          [],
+          txCallback,
+          ProtocolAction.borrow,
+        ),
       },
     ];
   }
@@ -794,6 +806,7 @@ export class Pool extends BaseService<IPool> implements PoolInterface {
         ),
       from: user,
       value: getTxValue(reserve, convertedAmount),
+      action: ProtocolAction.repay,
     });
 
     txs.push({
@@ -882,6 +895,7 @@ export class Pool extends BaseService<IPool> implements PoolInterface {
         ),
       from: user,
       value: getTxValue(reserve, convertedAmount),
+      action: ProtocolAction.repayWithPermit,
     });
 
     txs.push({
@@ -890,7 +904,7 @@ export class Pool extends BaseService<IPool> implements PoolInterface {
       gas: this.generateTxPriceEstimation(
         txs,
         txCallback,
-        ProtocolAction.repay,
+        ProtocolAction.repayWithPermit,
       ),
     });
 

--- a/packages/contract-helpers/src/v3-pool-contract/index.ts
+++ b/packages/contract-helpers/src/v3-pool-contract/index.ts
@@ -1162,6 +1162,7 @@ export class Pool extends BaseService<IPool> implements PoolInterface {
               referralCode ?? '0',
             ),
           from: user,
+          action: ProtocolAction.swapCollateral,
         });
 
       txs.push({
@@ -1322,6 +1323,7 @@ export class Pool extends BaseService<IPool> implements PoolInterface {
               referralCode ?? '0',
             ),
           from: user,
+          action: ProtocolAction.repayCollateral,
         });
 
       txs.push({

--- a/packages/contract-helpers/src/v3-pool-contract/pool.test.ts
+++ b/packages/contract-helpers/src/v3-pool-contract/pool.test.ts
@@ -121,7 +121,11 @@ describe('Pool', () => {
       const tx: transactionType = await txObj.tx();
       expect(tx.to).toEqual(POOL);
       expect(tx.from).toEqual(user);
-      expect(tx.gasLimit).toEqual(BigNumber.from(1));
+      expect(tx.gasLimit).toEqual(
+        BigNumber.from(
+          gasLimitRecommendations[ProtocolAction.supply].recommended,
+        ),
+      );
       expect(tx.value).toEqual(DEFAULT_NULL_VALUE_ON_TX);
 
       const decoded = utils.defaultAbiCoder.decode(
@@ -137,7 +141,9 @@ describe('Pool', () => {
       // gas price
       const gasPrice: GasType | null = await txObj.gas();
       expect(gasPrice).not.toBeNull();
-      expect(gasPrice?.gasLimit).toEqual('1');
+      expect(gasPrice?.gasLimit).toEqual(
+        gasLimitRecommendations[ProtocolAction.supply].recommended,
+      );
       expect(gasPrice?.gasPrice).toEqual('1');
     });
     it('Expects the tx object passing all parameters but not onBehalfOf', async () => {
@@ -170,7 +176,11 @@ describe('Pool', () => {
       const tx: transactionType = await txObj.tx();
       expect(tx.to).toEqual(POOL);
       expect(tx.from).toEqual(user);
-      expect(tx.gasLimit).toEqual(BigNumber.from(1));
+      expect(tx.gasLimit).toEqual(
+        BigNumber.from(
+          gasLimitRecommendations[ProtocolAction.supply].recommended,
+        ),
+      );
       expect(tx.value).toEqual(DEFAULT_NULL_VALUE_ON_TX);
 
       const decoded = utils.defaultAbiCoder.decode(
@@ -186,7 +196,9 @@ describe('Pool', () => {
       // gas price
       const gasPrice: GasType | null = await txObj.gas();
       expect(gasPrice).not.toBeNull();
-      expect(gasPrice?.gasLimit).toEqual('1');
+      expect(gasPrice?.gasLimit).toEqual(
+        gasLimitRecommendations[ProtocolAction.supply].recommended,
+      );
       expect(gasPrice?.gasPrice).toEqual('1');
     });
     it('Expects the tx object passing all parameters but not referral', async () => {
@@ -219,7 +231,11 @@ describe('Pool', () => {
       const tx: transactionType = await txObj.tx();
       expect(tx.to).toEqual(POOL);
       expect(tx.from).toEqual(user);
-      expect(tx.gasLimit).toEqual(BigNumber.from(1));
+      expect(tx.gasLimit).toEqual(
+        BigNumber.from(
+          gasLimitRecommendations[ProtocolAction.supply].recommended,
+        ),
+      );
       expect(tx.value).toEqual(DEFAULT_NULL_VALUE_ON_TX);
 
       const decoded = utils.defaultAbiCoder.decode(
@@ -235,7 +251,9 @@ describe('Pool', () => {
       // gas price
       const gasPrice: GasType | null = await txObj.gas();
       expect(gasPrice).not.toBeNull();
-      expect(gasPrice?.gasLimit).toEqual('1');
+      expect(gasPrice?.gasLimit).toEqual(
+        gasLimitRecommendations[ProtocolAction.supply].recommended,
+      );
       expect(gasPrice?.gasPrice).toEqual('1');
     });
     it('Expects the tx object passing all parameters and needing approval', async () => {
@@ -280,7 +298,11 @@ describe('Pool', () => {
       const tx: transactionType = await txObj.tx();
       expect(tx.to).toEqual(POOL);
       expect(tx.from).toEqual(user);
-      expect(tx.gasLimit).toEqual(BigNumber.from(1));
+      expect(tx.gasLimit).toEqual(
+        BigNumber.from(
+          gasLimitRecommendations[ProtocolAction.supply].recommended,
+        ),
+      );
       expect(tx.value).toEqual(DEFAULT_NULL_VALUE_ON_TX);
 
       const decoded = utils.defaultAbiCoder.decode(
@@ -463,7 +485,11 @@ describe('Pool', () => {
       const tx: transactionType = await txObj.tx();
       expect(tx.to).toEqual(POOL);
       expect(tx.from).toEqual(user);
-      expect(tx.gasLimit).toEqual(BigNumber.from(1));
+      expect(tx.gasLimit).toEqual(
+        BigNumber.from(
+          gasLimitRecommendations[ProtocolAction.supply].recommended,
+        ),
+      );
       expect(tx.value).toEqual(DEFAULT_NULL_VALUE_ON_TX);
 
       const decoded = utils.defaultAbiCoder.decode(
@@ -479,7 +505,9 @@ describe('Pool', () => {
       // gas price
       const gasPrice: GasType | null = await txObj.gas();
       expect(gasPrice).not.toBeNull();
-      expect(gasPrice?.gasLimit).toEqual('1');
+      expect(gasPrice?.gasLimit).toEqual(
+        gasLimitRecommendations[ProtocolAction.supply].recommended,
+      );
       expect(gasPrice?.gasPrice).toEqual('1');
     });
     it('Expects the tx object passing all parameters with optimal path enabled', async () => {
@@ -543,7 +571,11 @@ describe('Pool', () => {
       const tx: transactionType = await txObj.tx();
       expect(tx.to).toEqual(POOL);
       expect(tx.from).toEqual(user);
-      expect(tx.gasLimit).toEqual(BigNumber.from(1));
+      expect(tx.gasLimit).toEqual(
+        BigNumber.from(
+          gasLimitRecommendations[ProtocolAction.supply].recommended,
+        ),
+      );
       expect(tx.value).toEqual(DEFAULT_NULL_VALUE_ON_TX);
 
       const decoded = utils.defaultAbiCoder.decode(
@@ -559,7 +591,9 @@ describe('Pool', () => {
       // gas price
       const gasPrice: GasType | null = await txObj.gas();
       expect(gasPrice).not.toBeNull();
-      expect(gasPrice?.gasLimit).toEqual('1');
+      expect(gasPrice?.gasLimit).toEqual(
+        gasLimitRecommendations[ProtocolAction.supply].recommended,
+      );
       expect(gasPrice?.gasPrice).toEqual('1');
     });
     it('Expects the tx object passing all parameters but not referral', async () => {
@@ -592,7 +626,11 @@ describe('Pool', () => {
       const tx: transactionType = await txObj.tx();
       expect(tx.to).toEqual(POOL);
       expect(tx.from).toEqual(user);
-      expect(tx.gasLimit).toEqual(BigNumber.from(1));
+      expect(tx.gasLimit).toEqual(
+        BigNumber.from(
+          gasLimitRecommendations[ProtocolAction.supply].recommended,
+        ),
+      );
       expect(tx.value).toEqual(DEFAULT_NULL_VALUE_ON_TX);
 
       const decoded = utils.defaultAbiCoder.decode(
@@ -608,7 +646,9 @@ describe('Pool', () => {
       // gas price
       const gasPrice: GasType | null = await txObj.gas();
       expect(gasPrice).not.toBeNull();
-      expect(gasPrice?.gasLimit).toEqual('1');
+      expect(gasPrice?.gasLimit).toEqual(
+        gasLimitRecommendations[ProtocolAction.supply].recommended,
+      );
       expect(gasPrice?.gasPrice).toEqual('1');
     });
     it('Expects the tx object passing all parameters and needing approval', async () => {
@@ -653,7 +693,11 @@ describe('Pool', () => {
       const tx: transactionType = await txObj.tx();
       expect(tx.to).toEqual(POOL);
       expect(tx.from).toEqual(user);
-      expect(tx.gasLimit).toEqual(BigNumber.from(1));
+      expect(tx.gasLimit).toEqual(
+        BigNumber.from(
+          gasLimitRecommendations[ProtocolAction.supply].recommended,
+        ),
+      );
       expect(tx.value).toEqual(DEFAULT_NULL_VALUE_ON_TX);
 
       const decoded = utils.defaultAbiCoder.decode(
@@ -1009,7 +1053,11 @@ describe('Pool', () => {
       const tx: transactionType = await txObj.tx();
       expect(tx.to).toEqual(POOL);
       expect(tx.from).toEqual(user);
-      expect(tx.gasLimit).toEqual(BigNumber.from(1));
+      expect(tx.gasLimit).toEqual(
+        BigNumber.from(
+          gasLimitRecommendations[ProtocolAction.supplyWithPermit].recommended,
+        ),
+      );
       expect(tx.value).toEqual(DEFAULT_NULL_VALUE_ON_TX);
 
       const decoded = utils.defaultAbiCoder.decode(
@@ -1042,7 +1090,9 @@ describe('Pool', () => {
       // gas price
       const gasPrice: GasType | null = await txObj.gas();
       expect(gasPrice).not.toBeNull();
-      expect(gasPrice?.gasLimit).toEqual('1');
+      expect(gasPrice?.gasLimit).toEqual(
+        gasLimitRecommendations[ProtocolAction.supplyWithPermit].recommended,
+      );
       expect(gasPrice?.gasPrice).toEqual('1');
     });
     it('Expects the tx object if all params ok and optimal path chosen', async () => {
@@ -1088,7 +1138,11 @@ describe('Pool', () => {
       const tx: transactionType = await txObj.tx();
       expect(tx.to).toEqual(POOL);
       expect(tx.from).toEqual(user);
-      expect(tx.gasLimit).toEqual(BigNumber.from(1));
+      expect(tx.gasLimit).toEqual(
+        BigNumber.from(
+          gasLimitRecommendations[ProtocolAction.supplyWithPermit].recommended,
+        ),
+      );
       expect(tx.value).toEqual(DEFAULT_NULL_VALUE_ON_TX);
 
       const decoded = utils.defaultAbiCoder.decode(
@@ -1121,7 +1175,9 @@ describe('Pool', () => {
       // gas price
       const gasPrice: GasType | null = await txObj.gas();
       expect(gasPrice).not.toBeNull();
-      expect(gasPrice?.gasLimit).toEqual('1');
+      expect(gasPrice?.gasLimit).toEqual(
+        gasLimitRecommendations[ProtocolAction.supplyWithPermit].recommended,
+      );
       expect(gasPrice?.gasPrice).toEqual('1');
     });
     it('Expects the tx object if all params ok, without referralCode', async () => {
@@ -1145,7 +1201,11 @@ describe('Pool', () => {
       const tx: transactionType = await txObj.tx();
       expect(tx.to).toEqual(POOL);
       expect(tx.from).toEqual(user);
-      expect(tx.gasLimit).toEqual(BigNumber.from(1));
+      expect(tx.gasLimit).toEqual(
+        BigNumber.from(
+          gasLimitRecommendations[ProtocolAction.supplyWithPermit].recommended,
+        ),
+      );
       expect(tx.value).toEqual(DEFAULT_NULL_VALUE_ON_TX);
 
       const decoded = utils.defaultAbiCoder.decode(
@@ -1178,7 +1238,9 @@ describe('Pool', () => {
       // gas price
       const gasPrice: GasType | null = await txObj.gas();
       expect(gasPrice).not.toBeNull();
-      expect(gasPrice?.gasLimit).toEqual('1');
+      expect(gasPrice?.gasLimit).toEqual(
+        gasLimitRecommendations[ProtocolAction.supplyWithPermit].recommended,
+      );
       expect(gasPrice?.gasPrice).toEqual('1');
     });
     it('Expects to fail when sythetix is not validated', async () => {
@@ -1632,7 +1694,11 @@ describe('Pool', () => {
       const tx: transactionType = await txObj.tx();
       expect(tx.to).toEqual(POOL);
       expect(tx.from).toEqual(user);
-      expect(tx.gasLimit).toEqual(BigNumber.from(1));
+      expect(tx.gasLimit).toEqual(
+        BigNumber.from(
+          gasLimitRecommendations[ProtocolAction.borrow].recommended,
+        ),
+      );
 
       const decoded = utils.defaultAbiCoder.decode(
         ['address', 'uint256', 'uint256', 'uint16', 'address'],
@@ -1648,7 +1714,9 @@ describe('Pool', () => {
       // gas price
       const gasPrice: GasType | null = await txObj.gas();
       expect(gasPrice).not.toBeNull();
-      expect(gasPrice?.gasLimit).toEqual('1');
+      expect(gasPrice?.gasLimit).toEqual(
+        gasLimitRecommendations[ProtocolAction.borrow].recommended,
+      );
       expect(gasPrice?.gasPrice).toEqual('1');
     });
     it('Expects the tx object passing all parameters with optimal path selected', async () => {
@@ -1700,7 +1768,11 @@ describe('Pool', () => {
       const tx: transactionType = await txObj.tx();
       expect(tx.to).toEqual(POOL);
       expect(tx.from).toEqual(user);
-      expect(tx.gasLimit).toEqual(BigNumber.from(1));
+      expect(tx.gasLimit).toEqual(
+        BigNumber.from(
+          gasLimitRecommendations[ProtocolAction.borrow].recommended,
+        ),
+      );
 
       const decoded = utils.defaultAbiCoder.decode(
         ['address', 'uint256', 'uint256', 'uint16', 'address'],
@@ -1716,7 +1788,9 @@ describe('Pool', () => {
       // gas price
       const gasPrice: GasType | null = await txObj.gas();
       expect(gasPrice).not.toBeNull();
-      expect(gasPrice?.gasLimit).toEqual('1');
+      expect(gasPrice?.gasLimit).toEqual(
+        gasLimitRecommendations[ProtocolAction.borrow].recommended,
+      );
       expect(gasPrice?.gasPrice).toEqual('1');
     });
     it('Expects the tx object passing all parameters with Interest rate Variable', async () => {
@@ -1744,7 +1818,11 @@ describe('Pool', () => {
       const tx: transactionType = await txObj.tx();
       expect(tx.to).toEqual(POOL);
       expect(tx.from).toEqual(user);
-      expect(tx.gasLimit).toEqual(BigNumber.from(1));
+      expect(tx.gasLimit).toEqual(
+        BigNumber.from(
+          gasLimitRecommendations[ProtocolAction.borrow].recommended,
+        ),
+      );
 
       const decoded = utils.defaultAbiCoder.decode(
         ['address', 'uint256', 'uint256', 'uint16', 'address'],
@@ -1760,7 +1838,9 @@ describe('Pool', () => {
       // gas price
       const gasPrice: GasType | null = await txObj.gas();
       expect(gasPrice).not.toBeNull();
-      expect(gasPrice?.gasLimit).toEqual('1');
+      expect(gasPrice?.gasLimit).toEqual(
+        gasLimitRecommendations[ProtocolAction.borrow].recommended,
+      );
       expect(gasPrice?.gasPrice).toEqual('1');
     });
     it('Expects to fail when borrowing eth and not passing debtTokenAddress', async () => {
@@ -1951,7 +2031,11 @@ describe('Pool', () => {
       const tx: transactionType = await txObj.tx();
       expect(tx.to).toEqual(POOL);
       expect(tx.from).toEqual(user);
-      expect(tx.gasLimit).toEqual(BigNumber.from(1));
+      expect(tx.gasLimit).toEqual(
+        BigNumber.from(
+          gasLimitRecommendations[ProtocolAction.repay].recommended,
+        ),
+      );
       expect(tx.value).toEqual(DEFAULT_NULL_VALUE_ON_TX);
 
       const decoded = utils.defaultAbiCoder.decode(
@@ -1967,7 +2051,9 @@ describe('Pool', () => {
       // gas price
       const gasPrice: GasType | null = await txObj.gas();
       expect(gasPrice).not.toBeNull();
-      expect(gasPrice?.gasLimit).toEqual('1');
+      expect(gasPrice?.gasLimit).toEqual(
+        gasLimitRecommendations[ProtocolAction.repay].recommended,
+      );
       expect(gasPrice?.gasPrice).toEqual('1');
     });
     it('Expects the tx object passing all params without onBehalfOf and no approval', async () => {
@@ -2044,7 +2130,11 @@ describe('Pool', () => {
       const tx: transactionType = await txObj.tx();
       expect(tx.to).toEqual(POOL);
       expect(tx.from).toEqual(user);
-      expect(tx.gasLimit).toEqual(BigNumber.from(1));
+      expect(tx.gasLimit).toEqual(
+        BigNumber.from(
+          gasLimitRecommendations[ProtocolAction.repay].recommended,
+        ),
+      );
       expect(tx.value).toEqual(DEFAULT_NULL_VALUE_ON_TX);
 
       const decoded = utils.defaultAbiCoder.decode(
@@ -2108,7 +2198,11 @@ describe('Pool', () => {
       const tx: transactionType = await txObj.tx();
       expect(tx.to).toEqual(POOL);
       expect(tx.from).toEqual(user);
-      expect(tx.gasLimit).toEqual(BigNumber.from(1));
+      expect(tx.gasLimit).toEqual(
+        BigNumber.from(
+          gasLimitRecommendations[ProtocolAction.repay].recommended,
+        ),
+      );
       expect(tx.value).toEqual(DEFAULT_NULL_VALUE_ON_TX);
 
       const decoded = utils.defaultAbiCoder.decode(
@@ -2280,7 +2374,11 @@ describe('Pool', () => {
       const tx: transactionType = await txObj.tx();
       expect(tx.to).toEqual(POOL);
       expect(tx.from).toEqual(user);
-      expect(tx.gasLimit).toEqual(BigNumber.from(1));
+      expect(tx.gasLimit).toEqual(
+        BigNumber.from(
+          gasLimitRecommendations[ProtocolAction.repayWithPermit].recommended,
+        ),
+      );
       expect(tx.value).toEqual(DEFAULT_NULL_VALUE_ON_TX);
 
       const decoded = utils.defaultAbiCoder.decode(
@@ -2313,7 +2411,9 @@ describe('Pool', () => {
       // gas price
       const gasPrice: GasType | null = await txObj.gas();
       expect(gasPrice).not.toBeNull();
-      expect(gasPrice?.gasLimit).toEqual('1');
+      expect(gasPrice?.gasLimit).toEqual(
+        gasLimitRecommendations[ProtocolAction.repayWithPermit].recommended,
+      );
       expect(gasPrice?.gasPrice).toEqual('1');
     });
     it('Expects the tx object passing all params with optimal path', async () => {
@@ -2376,7 +2476,11 @@ describe('Pool', () => {
       const tx: transactionType = await txObj.tx();
       expect(tx.to).toEqual(POOL);
       expect(tx.from).toEqual(user);
-      expect(tx.gasLimit).toEqual(BigNumber.from(1));
+      expect(tx.gasLimit).toEqual(
+        BigNumber.from(
+          gasLimitRecommendations[ProtocolAction.repayWithPermit].recommended,
+        ),
+      );
       expect(tx.value).toEqual(DEFAULT_NULL_VALUE_ON_TX);
 
       const decoded = utils.defaultAbiCoder.decode(
@@ -2409,7 +2513,9 @@ describe('Pool', () => {
       // gas price
       const gasPrice: GasType | null = await txObj.gas();
       expect(gasPrice).not.toBeNull();
-      expect(gasPrice?.gasLimit).toEqual('1');
+      expect(gasPrice?.gasLimit).toEqual(
+        gasLimitRecommendations[ProtocolAction.repayWithPermit].recommended,
+      );
       expect(gasPrice?.gasPrice).toEqual('1');
     });
     it('Expects the tx object passing all params with with specific amount and synthetix repayment with valid amount and rate variable', async () => {
@@ -2442,7 +2548,11 @@ describe('Pool', () => {
       const tx: transactionType = await txObj.tx();
       expect(tx.to).toEqual(POOL);
       expect(tx.from).toEqual(user);
-      expect(tx.gasLimit).toEqual(BigNumber.from(1));
+      expect(tx.gasLimit).toEqual(
+        BigNumber.from(
+          gasLimitRecommendations[ProtocolAction.repayWithPermit].recommended,
+        ),
+      );
       expect(tx.value).toEqual(DEFAULT_NULL_VALUE_ON_TX);
 
       const decoded = utils.defaultAbiCoder.decode(
@@ -2475,7 +2585,9 @@ describe('Pool', () => {
       // gas price
       const gasPrice: GasType | null = await txObj.gas();
       expect(gasPrice).not.toBeNull();
-      expect(gasPrice?.gasLimit).toEqual('1');
+      expect(gasPrice?.gasLimit).toEqual(
+        gasLimitRecommendations[ProtocolAction.repayWithPermit].recommended,
+      );
       expect(gasPrice?.gasPrice).toEqual('1');
     });
     it('Expects to fail passing all params with with specific amount and synthetix repayment but not valid amount', async () => {
@@ -3278,7 +3390,12 @@ describe('Pool', () => {
       const tx: transactionType = await txObj.tx();
       expect(tx.to).toEqual(POOL);
       expect(tx.from).toEqual(user);
-      expect(tx.gasLimit).toEqual(BigNumber.from(1));
+
+      expect(tx.gasLimit).toEqual(
+        BigNumber.from(
+          gasLimitRecommendations[ProtocolAction.swapCollateral].recommended,
+        ),
+      );
       expect(tx.value).toEqual(DEFAULT_NULL_VALUE_ON_TX);
 
       const decoded = utils.defaultAbiCoder.decode(
@@ -3362,7 +3479,11 @@ describe('Pool', () => {
       const tx: transactionType = await txObj.tx();
       expect(tx.to).toEqual(POOL);
       expect(tx.from).toEqual(user);
-      expect(tx.gasLimit).toEqual(BigNumber.from(1));
+      expect(tx.gasLimit).toEqual(
+        BigNumber.from(
+          gasLimitRecommendations[ProtocolAction.swapCollateral].recommended,
+        ),
+      );
       expect(tx.value).toEqual(DEFAULT_NULL_VALUE_ON_TX);
 
       const decoded = utils.defaultAbiCoder.decode(
@@ -3406,7 +3527,9 @@ describe('Pool', () => {
       // gas price
       const gasPrice: GasType | null = await txObj.gas();
       expect(gasPrice).not.toBeNull();
-      expect(gasPrice?.gasLimit).toEqual('1');
+      expect(gasPrice?.gasLimit).toEqual(
+        gasLimitRecommendations[ProtocolAction.swapCollateral].recommended,
+      );
       expect(gasPrice?.gasPrice).toEqual('1');
     });
     it('Expects the tx object passing all params without referralCode and no approval needed for flash', async () => {
@@ -3443,7 +3566,11 @@ describe('Pool', () => {
       const tx: transactionType = await txObj.tx();
       expect(tx.to).toEqual(POOL);
       expect(tx.from).toEqual(user);
-      expect(tx.gasLimit).toEqual(BigNumber.from(1));
+      expect(tx.gasLimit).toEqual(
+        BigNumber.from(
+          gasLimitRecommendations[ProtocolAction.swapCollateral].recommended,
+        ),
+      );
       expect(tx.value).toEqual(DEFAULT_NULL_VALUE_ON_TX);
 
       const decoded = utils.defaultAbiCoder.decode(
@@ -3487,7 +3614,9 @@ describe('Pool', () => {
       // gas price
       const gasPrice: GasType | null = await txObj.gas();
       expect(gasPrice).not.toBeNull();
-      expect(gasPrice?.gasLimit).toEqual('1');
+      expect(gasPrice?.gasLimit).toEqual(
+        gasLimitRecommendations[ProtocolAction.swapCollateral].recommended,
+      );
       expect(gasPrice?.gasPrice).toEqual('1');
     });
     it('Expects the tx object passing all params and no approval needed with flash and no swapAll', async () => {
@@ -3525,7 +3654,11 @@ describe('Pool', () => {
       const tx: transactionType = await txObj.tx();
       expect(tx.to).toEqual(POOL);
       expect(tx.from).toEqual(user);
-      expect(tx.gasLimit).toEqual(BigNumber.from(1));
+      expect(tx.gasLimit).toEqual(
+        BigNumber.from(
+          gasLimitRecommendations[ProtocolAction.swapCollateral].recommended,
+        ),
+      );
       expect(tx.value).toEqual(DEFAULT_NULL_VALUE_ON_TX);
 
       const decoded = utils.defaultAbiCoder.decode(
@@ -3569,7 +3702,9 @@ describe('Pool', () => {
       // gas price
       const gasPrice: GasType | null = await txObj.gas();
       expect(gasPrice).not.toBeNull();
-      expect(gasPrice?.gasLimit).toEqual('1');
+      expect(gasPrice?.gasLimit).toEqual(
+        gasLimitRecommendations[ProtocolAction.swapCollateral].recommended,
+      );
       expect(gasPrice?.gasPrice).toEqual('1');
     });
     it('Expects the tx object passing all params without permitSignature and no approval needed without flash', async () => {
@@ -3926,7 +4061,11 @@ describe('Pool', () => {
       const tx: transactionType = await txObj.tx();
       expect(tx.to).toEqual(POOL);
       expect(tx.from).toEqual(user);
-      expect(tx.gasLimit).toEqual(BigNumber.from(1));
+      expect(tx.gasLimit).toEqual(
+        BigNumber.from(
+          gasLimitRecommendations[ProtocolAction.repayCollateral].recommended,
+        ),
+      );
       expect(tx.value).toEqual(DEFAULT_NULL_VALUE_ON_TX);
 
       const decoded = utils.defaultAbiCoder.decode(
@@ -4014,7 +4153,11 @@ describe('Pool', () => {
       const tx: transactionType = await txObj.tx();
       expect(tx.to).toEqual(POOL);
       expect(tx.from).toEqual(user);
-      expect(tx.gasLimit).toEqual(BigNumber.from(1));
+      expect(tx.gasLimit).toEqual(
+        BigNumber.from(
+          gasLimitRecommendations[ProtocolAction.repayCollateral].recommended,
+        ),
+      );
       expect(tx.value).toEqual(DEFAULT_NULL_VALUE_ON_TX);
 
       const decoded = utils.defaultAbiCoder.decode(
@@ -4060,7 +4203,9 @@ describe('Pool', () => {
       // gas price
       const gasPrice: GasType | null = await txObj.gas();
       expect(gasPrice).not.toBeNull();
-      expect(gasPrice?.gasLimit).toEqual('1');
+      expect(gasPrice?.gasLimit).toEqual(
+        gasLimitRecommendations[ProtocolAction.repayCollateral].recommended,
+      );
       expect(gasPrice?.gasPrice).toEqual('1');
     });
     it('Expects the tx object passing all params and no approval needed for flash with rate mode Variable', async () => {
@@ -4100,7 +4245,11 @@ describe('Pool', () => {
       const tx: transactionType = await txObj.tx();
       expect(tx.to).toEqual(POOL);
       expect(tx.from).toEqual(user);
-      expect(tx.gasLimit).toEqual(BigNumber.from(1));
+      expect(tx.gasLimit).toEqual(
+        BigNumber.from(
+          gasLimitRecommendations[ProtocolAction.repayCollateral].recommended,
+        ),
+      );
       expect(tx.value).toEqual(DEFAULT_NULL_VALUE_ON_TX);
 
       const decoded = utils.defaultAbiCoder.decode(
@@ -4146,7 +4295,9 @@ describe('Pool', () => {
       // gas price
       const gasPrice: GasType | null = await txObj.gas();
       expect(gasPrice).not.toBeNull();
-      expect(gasPrice?.gasLimit).toEqual('1');
+      expect(gasPrice?.gasLimit).toEqual(
+        gasLimitRecommendations[ProtocolAction.repayCollateral].recommended,
+      );
       expect(gasPrice?.gasPrice).toEqual('1');
     });
     it('Expects the tx object passing all params and no approval needed for flash without onBehalfOf', async () => {
@@ -4185,7 +4336,11 @@ describe('Pool', () => {
       const tx: transactionType = await txObj.tx();
       expect(tx.to).toEqual(POOL);
       expect(tx.from).toEqual(user);
-      expect(tx.gasLimit).toEqual(BigNumber.from(1));
+      expect(tx.gasLimit).toEqual(
+        BigNumber.from(
+          gasLimitRecommendations[ProtocolAction.repayCollateral].recommended,
+        ),
+      );
       expect(tx.value).toEqual(DEFAULT_NULL_VALUE_ON_TX);
 
       const decoded = utils.defaultAbiCoder.decode(
@@ -4231,7 +4386,9 @@ describe('Pool', () => {
       // gas price
       const gasPrice: GasType | null = await txObj.gas();
       expect(gasPrice).not.toBeNull();
-      expect(gasPrice?.gasLimit).toEqual('1');
+      expect(gasPrice?.gasLimit).toEqual(
+        gasLimitRecommendations[ProtocolAction.repayCollateral].recommended,
+      );
       expect(gasPrice?.gasPrice).toEqual('1');
     });
     it('Expects the tx object passing all params and no approval needed for flash without referralCode', async () => {
@@ -4270,7 +4427,11 @@ describe('Pool', () => {
       const tx: transactionType = await txObj.tx();
       expect(tx.to).toEqual(POOL);
       expect(tx.from).toEqual(user);
-      expect(tx.gasLimit).toEqual(BigNumber.from(1));
+      expect(tx.gasLimit).toEqual(
+        BigNumber.from(
+          gasLimitRecommendations[ProtocolAction.repayCollateral].recommended,
+        ),
+      );
       expect(tx.value).toEqual(DEFAULT_NULL_VALUE_ON_TX);
 
       const decoded = utils.defaultAbiCoder.decode(
@@ -4316,7 +4477,9 @@ describe('Pool', () => {
       // gas price
       const gasPrice: GasType | null = await txObj.gas();
       expect(gasPrice).not.toBeNull();
-      expect(gasPrice?.gasLimit).toEqual('1');
+      expect(gasPrice?.gasLimit).toEqual(
+        gasLimitRecommendations[ProtocolAction.repayCollateral].recommended,
+      );
       expect(gasPrice?.gasPrice).toEqual('1');
     });
     it('Expects the tx object passing all params and no approval needed without flash and not repayAllDebt', async () => {
@@ -4355,7 +4518,11 @@ describe('Pool', () => {
       const tx: transactionType = await txObj.tx();
       expect(tx.to).toEqual(POOL);
       expect(tx.from).toEqual(user);
-      expect(tx.gasLimit).toEqual(BigNumber.from(1));
+      expect(tx.gasLimit).toEqual(
+        BigNumber.from(
+          gasLimitRecommendations[ProtocolAction.repayCollateral].recommended,
+        ),
+      );
       expect(tx.value).toEqual(DEFAULT_NULL_VALUE_ON_TX);
 
       const decoded = utils.defaultAbiCoder.decode(
@@ -4401,7 +4568,9 @@ describe('Pool', () => {
       // gas price
       const gasPrice: GasType | null = await txObj.gas();
       expect(gasPrice).not.toBeNull();
-      expect(gasPrice?.gasLimit).toEqual('1');
+      expect(gasPrice?.gasLimit).toEqual(
+        gasLimitRecommendations[ProtocolAction.repayCollateral].recommended,
+      );
       expect(gasPrice?.gasPrice).toEqual('1');
     });
     it('Expects the tx object passing all params and no permitSignature, and no flash', async () => {

--- a/packages/contract-helpers/src/v3-pool-rollups/index.ts
+++ b/packages/contract-helpers/src/v3-pool-rollups/index.ts
@@ -108,6 +108,7 @@ export class L2Pool extends BaseService<IL2Pool> implements L2PoolInterface {
         l2PoolContract.populateTransaction.supply(encodedParams),
       from: user,
       value: getTxValue(reserve, amount),
+      action: ProtocolAction.supply,
     });
 
     txs.push({
@@ -162,12 +163,17 @@ export class L2Pool extends BaseService<IL2Pool> implements L2PoolInterface {
           permitS,
         ),
       from: user,
+      action: ProtocolAction.supplyWithPermit,
     });
 
     txs.push({
       tx: txCallback,
       txType: eEthereumTxType.DLP_ACTION,
-      gas: this.generateTxPriceEstimation(txs, txCallback),
+      gas: this.generateTxPriceEstimation(
+        txs,
+        txCallback,
+        ProtocolAction.supplyWithPermit,
+      ),
     });
 
     return txs;
@@ -204,7 +210,7 @@ export class L2Pool extends BaseService<IL2Pool> implements L2PoolInterface {
         gas: this.generateTxPriceEstimation(
           [],
           txCallback,
-          ProtocolAction.supply,
+          ProtocolAction.withdraw,
         ),
       },
     ];
@@ -235,13 +241,18 @@ export class L2Pool extends BaseService<IL2Pool> implements L2PoolInterface {
       rawTxMethod: async () =>
         l2PoolContract.populateTransaction.borrow(encodedParams),
       from: user,
+      action: ProtocolAction.borrow,
     });
 
     return [
       {
         tx: txCallback,
         txType: eEthereumTxType.DLP_ACTION,
-        gas: this.generateTxPriceEstimation([], txCallback),
+        gas: this.generateTxPriceEstimation(
+          [],
+          txCallback,
+          ProtocolAction.borrow,
+        ),
       },
     ];
   }
@@ -266,6 +277,7 @@ export class L2Pool extends BaseService<IL2Pool> implements L2PoolInterface {
         l2PoolContract.populateTransaction.repay(encodedParams),
       from: user,
       value: getTxValue(reserve, amount),
+      action: ProtocolAction.repay,
     });
 
     txs.push({
@@ -321,6 +333,7 @@ export class L2Pool extends BaseService<IL2Pool> implements L2PoolInterface {
         ),
       from: user,
       value: getTxValue(reserve, amount),
+      action: ProtocolAction.repayWithPermit,
     });
 
     txs.push({
@@ -356,6 +369,7 @@ export class L2Pool extends BaseService<IL2Pool> implements L2PoolInterface {
         l2PoolContract.populateTransaction.repayWithATokens(encodedParams),
       from: user,
       value: getTxValue(reserve, amount),
+      action: ProtocolAction.repay,
     });
 
     txs.push({

--- a/packages/contract-helpers/src/v3-pool-rollups/index.ts
+++ b/packages/contract-helpers/src/v3-pool-rollups/index.ts
@@ -108,7 +108,6 @@ export class L2Pool extends BaseService<IL2Pool> implements L2PoolInterface {
         l2PoolContract.populateTransaction.supply(encodedParams),
       from: user,
       value: getTxValue(reserve, amount),
-      action: ProtocolAction.supply,
     });
 
     txs.push({
@@ -163,17 +162,12 @@ export class L2Pool extends BaseService<IL2Pool> implements L2PoolInterface {
           permitS,
         ),
       from: user,
-      action: ProtocolAction.supplyWithPermit,
     });
 
     txs.push({
       tx: txCallback,
       txType: eEthereumTxType.DLP_ACTION,
-      gas: this.generateTxPriceEstimation(
-        txs,
-        txCallback,
-        ProtocolAction.supplyWithPermit,
-      ),
+      gas: this.generateTxPriceEstimation(txs, txCallback),
     });
 
     return txs;
@@ -210,7 +204,7 @@ export class L2Pool extends BaseService<IL2Pool> implements L2PoolInterface {
         gas: this.generateTxPriceEstimation(
           [],
           txCallback,
-          ProtocolAction.withdraw,
+          ProtocolAction.supply,
         ),
       },
     ];
@@ -241,18 +235,13 @@ export class L2Pool extends BaseService<IL2Pool> implements L2PoolInterface {
       rawTxMethod: async () =>
         l2PoolContract.populateTransaction.borrow(encodedParams),
       from: user,
-      action: ProtocolAction.borrow,
     });
 
     return [
       {
         tx: txCallback,
         txType: eEthereumTxType.DLP_ACTION,
-        gas: this.generateTxPriceEstimation(
-          [],
-          txCallback,
-          ProtocolAction.borrow,
-        ),
+        gas: this.generateTxPriceEstimation([], txCallback),
       },
     ];
   }
@@ -277,7 +266,6 @@ export class L2Pool extends BaseService<IL2Pool> implements L2PoolInterface {
         l2PoolContract.populateTransaction.repay(encodedParams),
       from: user,
       value: getTxValue(reserve, amount),
-      action: ProtocolAction.repay,
     });
 
     txs.push({
@@ -333,7 +321,6 @@ export class L2Pool extends BaseService<IL2Pool> implements L2PoolInterface {
         ),
       from: user,
       value: getTxValue(reserve, amount),
-      action: ProtocolAction.repayWithPermit,
     });
 
     txs.push({
@@ -369,7 +356,6 @@ export class L2Pool extends BaseService<IL2Pool> implements L2PoolInterface {
         l2PoolContract.populateTransaction.repayWithATokens(encodedParams),
       from: user,
       value: getTxValue(reserve, amount),
-      action: ProtocolAction.repay,
     });
 
     txs.push({


### PR DESCRIPTION
Logic for updating gas limit if estimation < action default is only applied in `generateTxCallback`. This adds the correct action to all V2 and V3 methods


Developer Notes: 
- Skipped updates L2Pool estimates (v3-pool-rollup), need to test to make sure limits are correct
- In Pool helper (v3-pool-contract), `deposit` still exists for backwards-compatibility but `ProtocolAction.supply` is used for gas estimation ( `ProtocolAction.deposit` is only used in V2)