### PR TITLE
fix: check for liq threshold in place of ltv for user collateral check

### DIFF
--- a/packages/math-utils/src/formatters/user/calculate-user-reserve-totals.ts
+++ b/packages/math-utils/src/formatters/user/calculate-user-reserve-totals.ts
@@ -40,7 +40,8 @@ export function calculateUserReserveTotals({
       .plus(userReserveSummary.stableBorrowsMarketReferenceCurrency);
 
     if (
-      userReserveSummary.userReserve.reserve.usageAsCollateralEnabled &&
+      userReserveSummary.userReserve.reserve.reserveLiquidationThreshold !==
+        '0' &&
       userReserveSummary.userReserve.usageAsCollateralEnabledOnUser
     ) {
       if (userReserveSummary.userReserve.reserve.debtCeiling !== '0') {


### PR DESCRIPTION
An asset can have further collateral usage disabled by setting LTV to 0, while maintaining collateralization for existing suppliers. This changes the check on reserve collateralization enabled from LTV to Liquidation Threshold to match contract HF calculation