### PR TITLE
chore: restrict ethers to v5

### DIFF
--- a/packages/contract-helpers/package.json
+++ b/packages/contract-helpers/package.json
@@ -17,7 +17,7 @@
   },
   "peerDependencies": {
     "bignumber.js": "^9.x",
-    "ethers": "^5.x",
+    "ethers": ">=5.0.0 <6.0.0",
     "reflect-metadata": "^0.1.x",
     "tslib": "^2.4.x"
   },


### PR DESCRIPTION
v6 introduces breaking changes, specifically to `utils` imports, so the `peerDependency` should be updated to v5