### PR TITLE
feat: add Scroll Alpha Testnet chainId

### DIFF
--- a/packages/contract-helpers/src/commons/types.ts
+++ b/packages/contract-helpers/src/commons/types.ts
@@ -32,6 +32,7 @@ export const ChainIdToNetwork: Record<number, string> = {
   1666600000: 'harmony',
   1666700000: 'harmony_testnet',
   11155111: 'sepolia',
+  534353: 'scroll_alpha',
 };
 
 export enum ChainId {
@@ -57,6 +58,7 @@ export enum ChainId {
   harmony_testnet = 1666700000,
   zkevm_testnet = 1402,
   sepolia = 11155111,
+  scroll_alpha = 534353,
 }
 export type ConstantAddressesByNetwork = Record<
   string,


### PR DESCRIPTION
Hoping to add Scroll Alpha's chainId for use in a PR to `aave-interface`.

Context: Aave Governance [recently voted](https://governance.aave.com/t/deploy-aave-v3-on-scroll-testnet/11861) to allow testnet deployment on Scroll's Alpha Testnet. Scroll Alpha contracts have already been added to `@bgd-labs/aave-address-book` in [this PR](https://github.com/bgd-labs/aave-address-book/pull/112).