### PR TITLE
fix: apply default gas limits

### DIFF
--- a/packages/contract-helpers/src/baseDebtToken-contract/index.ts
+++ b/packages/contract-helpers/src/baseDebtToken-contract/index.ts
@@ -3,10 +3,11 @@ import BaseService from '../commons/BaseService';
 import {
   eEthereumTxType,
   EthereumTransactionTypeExtended,
+  ProtocolAction,
   tEthereumAddress,
   transactionType,
 } from '../commons/types';
-import { valueToWei } from '../commons/utils';
+import { gasLimitRecommendations, valueToWei } from '../commons/utils';
 import { DebtTokenValidator } from '../commons/validators/methodValidators';
 import {
   isEthAddress,
@@ -125,6 +126,10 @@ export class BaseDebtToken
       data: txData,
       to: debtTokenAddress,
       from: user,
+      gasLimit: BigNumber.from(
+        gasLimitRecommendations[ProtocolAction.creditDelegationApproval]
+          .recommended,
+      ),
     };
     return approveDelegationTx;
   }

--- a/packages/contract-helpers/src/commons/types.ts
+++ b/packages/contract-helpers/src/commons/types.ts
@@ -115,6 +115,8 @@ export enum ProtocolAction {
   supplyWithPermit = 'supplyWithPermit',
   repayWithPermit = 'repayWithPermit',
   vote = 'vote',
+  approval = 'approval',
+  creditDelegationApproval = 'creditDelegationApproval',
 }
 
 export enum GovernanceVote {

--- a/packages/contract-helpers/src/commons/utils.ts
+++ b/packages/contract-helpers/src/commons/utils.ts
@@ -42,6 +42,14 @@ export const gasLimitRecommendations: GasRecommendationType = {
     limit: '210000',
     recommended: '210000',
   },
+  [ProtocolAction.approval]: {
+    limit: '65000',
+    recommended: '65000',
+  },
+  [ProtocolAction.creditDelegationApproval]: {
+    limit: '55000',
+    recommended: '55000',
+  },
   [ProtocolAction.supply]: {
     limit: '300000',
     recommended: '300000',

--- a/packages/contract-helpers/src/erc20-contract/index.ts
+++ b/packages/contract-helpers/src/erc20-contract/index.ts
@@ -3,6 +3,7 @@ import BaseService from '../commons/BaseService';
 import {
   eEthereumTxType,
   EthereumTransactionTypeExtended,
+  ProtocolAction,
   tEthereumAddress,
   transactionType,
 } from '../commons/types';
@@ -11,6 +12,7 @@ import {
   valueToWei,
   SUPER_BIG_ALLOWANCE_NUMBER,
   MAX_UINT_AMOUNT,
+  gasLimitRecommendations,
 } from '../commons/utils';
 import { ERC20Validator } from '../commons/validators/methodValidators';
 import {
@@ -135,6 +137,9 @@ export class ERC20Service
     tx.data = txData;
     tx.to = token;
     tx.from = user;
+    tx.gasLimit = BigNumber.from(
+      gasLimitRecommendations[ProtocolAction.approval].recommended,
+    );
 
     return tx;
   }

--- a/packages/contract-helpers/src/lendingPool-contract-bundle/index.ts
+++ b/packages/contract-helpers/src/lendingPool-contract-bundle/index.ts
@@ -1,12 +1,16 @@
-import { providers, PopulatedTransaction } from 'ethers';
+import { providers, PopulatedTransaction, BigNumber } from 'ethers';
 import BaseService from '../commons/BaseService';
 import {
   BorrowTxBuilder,
   InterestRate,
   LendingPoolMarketConfig,
+  ProtocolAction,
   tEthereumAddress,
 } from '../commons/types';
-import { API_ETH_MOCK_ADDRESS } from '../commons/utils';
+import {
+  API_ETH_MOCK_ADDRESS,
+  gasLimitRecommendations,
+} from '../commons/utils';
 import {
   ApproveType,
   ERC20Service,
@@ -127,6 +131,9 @@ export class LendingPoolBundle
           actionTx.to = this.lendingPoolAddress;
           actionTx.from = user;
           actionTx.data = txData;
+          actionTx.gasLimit = BigNumber.from(
+            gasLimitRecommendations[ProtocolAction.deposit].recommended,
+          );
         }
 
         return actionTx;
@@ -176,6 +183,9 @@ export class LendingPoolBundle
           actionTx.to = this.lendingPoolAddress;
           actionTx.from = user;
           actionTx.data = txData;
+          actionTx.gasLimit = BigNumber.from(
+            gasLimitRecommendations[ProtocolAction.borrow].recommended,
+          );
         }
 
         return actionTx;

--- a/packages/contract-helpers/src/v3-pool-contract-bundle/index.ts
+++ b/packages/contract-helpers/src/v3-pool-contract-bundle/index.ts
@@ -1,12 +1,16 @@
 import { Signature, splitSignature } from '@ethersproject/bytes';
-import { PopulatedTransaction, providers } from 'ethers';
+import { BigNumber, PopulatedTransaction, providers } from 'ethers';
 import BaseService from '../commons/BaseService';
 import {
   BorrowTxBuilder,
   InterestRate,
+  ProtocolAction,
   tEthereumAddress,
 } from '../commons/types';
-import { API_ETH_MOCK_ADDRESS } from '../commons/utils';
+import {
+  API_ETH_MOCK_ADDRESS,
+  gasLimitRecommendations,
+} from '../commons/utils';
 import { ERC20_2612Service, ERC20_2612Interface } from '../erc20-2612';
 import {
   ApproveType,
@@ -185,6 +189,9 @@ export class PoolBundle
           actionTx.to = this.poolAddress;
           actionTx.from = user;
           actionTx.data = txData;
+          actionTx.gasLimit = BigNumber.from(
+            gasLimitRecommendations[ProtocolAction.supply].recommended,
+          );
         }
 
         return actionTx;
@@ -244,6 +251,10 @@ export class PoolBundle
           populatedTx.to = this.poolAddress;
           populatedTx.from = user;
           populatedTx.data = txData;
+          populatedTx.gasLimit = BigNumber.from(
+            gasLimitRecommendations[ProtocolAction.supplyWithPermit]
+              .recommended,
+          );
         }
 
         return populatedTx;
@@ -310,6 +321,9 @@ export class PoolBundle
           actionTx.to = this.poolAddress;
           actionTx.from = user;
           actionTx.data = txData;
+          actionTx.gasLimit = BigNumber.from(
+            gasLimitRecommendations[ProtocolAction.borrow].recommended,
+          );
         }
 
         return actionTx;

--- a/packages/contract-helpers/src/v3-pool-rollups/index.ts
+++ b/packages/contract-helpers/src/v3-pool-rollups/index.ts
@@ -1,4 +1,4 @@
-import { PopulatedTransaction, providers, Signature } from 'ethers';
+import { BigNumber, PopulatedTransaction, providers, Signature } from 'ethers';
 import { splitSignature } from 'ethers/lib/utils';
 import BaseService from '../commons/BaseService';
 import {
@@ -7,7 +7,7 @@ import {
   ProtocolAction,
   transactionType,
 } from '../commons/types';
-import { getTxValue } from '../commons/utils';
+import { gasLimitRecommendations, getTxValue } from '../commons/utils';
 import { L2PValidator } from '../commons/validators/methodValidators';
 import { isDeadline32Bytes } from '../commons/validators/paramValidators';
 import { LPSupplyParamsType } from '../v3-pool-contract/lendingPoolTypes';
@@ -178,6 +178,9 @@ export class L2Pool extends BaseService<IL2Pool> implements L2PoolInterface {
       actionTx.to = this.l2PoolAddress;
       actionTx.from = user;
       actionTx.data = txData;
+      actionTx.gasLimit = BigNumber.from(
+        gasLimitRecommendations[ProtocolAction.borrow].limit,
+      );
       return actionTx;
     };
 
@@ -229,6 +232,9 @@ export class L2Pool extends BaseService<IL2Pool> implements L2PoolInterface {
       actionTx.to = this.l2PoolAddress;
       actionTx.data = txData;
       actionTx.from = user;
+      actionTx.gasLimit = BigNumber.from(
+        gasLimitRecommendations[ProtocolAction.supply].limit,
+      );
       return actionTx;
     };
 
@@ -247,6 +253,9 @@ export class L2Pool extends BaseService<IL2Pool> implements L2PoolInterface {
       actionTx.to = this.l2PoolAddress;
       actionTx.data = txData;
       actionTx.from = user;
+      actionTx.gasLimit = BigNumber.from(
+        gasLimitRecommendations[ProtocolAction.borrow].limit,
+      );
       return actionTx;
     };
 
@@ -269,6 +278,9 @@ export class L2Pool extends BaseService<IL2Pool> implements L2PoolInterface {
       actionTx.to = this.l2PoolAddress;
       actionTx.data = txData;
       actionTx.from = user;
+      actionTx.gasLimit = BigNumber.from(
+        gasLimitRecommendations[ProtocolAction.supplyWithPermit].limit,
+      );
       return actionTx;
     };
   }

--- a/packages/contract-helpers/src/wethgateway-contract/index.ts
+++ b/packages/contract-helpers/src/wethgateway-contract/index.ts
@@ -12,7 +12,7 @@ import {
   tEthereumAddress,
   transactionType,
 } from '../commons/types';
-import { valueToWei } from '../commons/utils';
+import { gasLimitRecommendations, valueToWei } from '../commons/utils';
 import { WETHValidator } from '../commons/validators/methodValidators';
 import {
   is0OrPositiveAmount,
@@ -125,6 +125,9 @@ export class WETHGatewayService
         to: this.wethGatewayAddress,
         from: args.user,
         value: BigNumber.from(args.amount),
+        gasLimit: BigNumber.from(
+          gasLimitRecommendations[ProtocolAction.deposit].limit,
+        ),
       };
       return actionTx;
     };
@@ -144,6 +147,9 @@ export class WETHGatewayService
         data: txData,
         to: this.wethGatewayAddress,
         from: args.user,
+        gasLimit: BigNumber.from(
+          gasLimitRecommendations[ProtocolAction.borrowETH].limit,
+        ),
       };
       return actionTx;
     };


### PR DESCRIPTION
- Add default estimations for approve and approveDelegation
- Apply default gas limit to all tx data generation methods (note: this is an L1 estimate, L2s may have different logic for computing gas limit which will need to be handled separately or rely on calling `estimateGas` from the UI)