### PR TITLE
fix: integer rounding for migration credit delegation approval buffer

### DIFF
--- a/packages/contract-helpers/src/v3-migration-contract/index.ts
+++ b/packages/contract-helpers/src/v3-migration-contract/index.ts
@@ -160,7 +160,10 @@ export class V3MigrationHelperService
         const asset = assets[index];
         const originalAmount = new BigNumber(asset.amount);
         const tenPercent = originalAmount.dividedBy(10);
-        const amountPlusBuffer = originalAmount.plus(tenPercent).toString();
+        const amountPlusBuffer = originalAmount
+          .plus(tenPercent)
+          .integerValue()
+          .toString();
 
         return this.baseDebtTokenService.approveDelegation({
           user,


### PR DESCRIPTION
The `amountPlusBuffer` is directly passed to `ethers.populateTransaction` which will error with a non-integer input