### PR TITLE
fix: decimal formatting in credit delegation approval checks

### DIFF
--- a/packages/contract-helpers/src/baseDebtToken-contract/index.ts
+++ b/packages/contract-helpers/src/baseDebtToken-contract/index.ts
@@ -1,5 +1,4 @@
 import { BigNumber, ethers, PopulatedTransaction, providers } from 'ethers';
-import { formatUnits } from 'ethers/lib/utils';
 import BaseService from '../commons/BaseService';
 import {
   eEthereumTxType,
@@ -161,12 +160,9 @@ export class BaseDebtToken
         allowanceReceiver,
       );
 
-    const amountBNWithDecimals: BigNumber = BigNumber.from(
-      valueToWei(
-        nativeDecimals ? formatUnits(amount, decimals) : amount,
-        decimals,
-      ),
-    );
+    const amountBNWithDecimals: BigNumber = nativeDecimals
+      ? BigNumber.from(amount)
+      : BigNumber.from(valueToWei(amount, decimals));
 
     return delegatedAllowance.gte(amountBNWithDecimals);
   }

--- a/packages/contract-helpers/src/v3-migration-contract/index.ts
+++ b/packages/contract-helpers/src/v3-migration-contract/index.ts
@@ -36,8 +36,7 @@ export interface V3MigrationHelperInterface {
 
 export class V3MigrationHelperService
   extends BaseService<IMigrationHelper>
-  implements V3MigrationHelperInterface
-{
+  implements V3MigrationHelperInterface {
   readonly baseDebtTokenService: BaseDebtTokenInterface;
   readonly provider: providers.Provider;
   readonly MIGRATOR_ADDRESS: tEthereumAddress;
@@ -160,10 +159,7 @@ export class V3MigrationHelperService
         const asset = assets[index];
         const originalAmount = new BigNumber(asset.amount);
         const tenPercent = originalAmount.dividedBy(10);
-        const amountPlusBuffer = originalAmount
-          .plus(tenPercent)
-          .integerValue()
-          .toString();
+        const amountPlusBuffer = originalAmount.plus(tenPercent).toFixed(0);
 
         return this.baseDebtTokenService.approveDelegation({
           user,

--- a/packages/contract-helpers/src/v3-migration-contract/index.ts
+++ b/packages/contract-helpers/src/v3-migration-contract/index.ts
@@ -36,7 +36,8 @@ export interface V3MigrationHelperInterface {
 
 export class V3MigrationHelperService
   extends BaseService<IMigrationHelper>
-  implements V3MigrationHelperInterface {
+  implements V3MigrationHelperInterface
+{
   readonly baseDebtTokenService: BaseDebtTokenInterface;
   readonly provider: providers.Provider;
   readonly MIGRATOR_ADDRESS: tEthereumAddress;


### PR DESCRIPTION
Replace `.integerValue().toString()` with `.toFixed()` which does not convert to scientific notation + simplify decimal formatting in `isDelegationApproved`