### PR TITLE
fix: gas limits

### DIFF
--- a/packages/contract-helpers/src/commons/types.ts
+++ b/packages/contract-helpers/src/commons/types.ts
@@ -119,6 +119,9 @@ export enum ProtocolAction {
   vote = 'vote',
   approval = 'approval',
   creditDelegationApproval = 'creditDelegationApproval',
+  stake = 'stake',
+  claimRewards = 'claimRewards',
+  setUsageAsCollateral = 'setUsageAsCollateral',
 }
 
 export enum GovernanceVote {

--- a/packages/contract-helpers/src/commons/utils.ts
+++ b/packages/contract-helpers/src/commons/utils.ts
@@ -110,6 +110,18 @@ export const gasLimitRecommendations: GasRecommendationType = {
     limit: '125000',
     recommended: '125000',
   },
+  [ProtocolAction.stake]: {
+    limit: '395000',
+    recommended: '395000',
+  },
+  [ProtocolAction.claimRewards]: {
+    limit: '275000',
+    recommended: '275000',
+  },
+  [ProtocolAction.setUsageAsCollateral]: {
+    limit: '138000',
+    recommended: '138000',
+  },
 };
 
 export const mintAmountsPerToken: Record<string, string> = {

--- a/packages/contract-helpers/src/lendingPool-contract/index.ts
+++ b/packages/contract-helpers/src/lendingPool-contract/index.ts
@@ -543,13 +543,18 @@ export class LendingPool
           usageAsCollateral,
         ),
       from: user,
+      action: ProtocolAction.setUsageAsCollateral,
     });
 
     return [
       {
         tx: txCallback,
         txType: eEthereumTxType.DLP_ACTION,
-        gas: this.generateTxPriceEstimation([], txCallback),
+        gas: this.generateTxPriceEstimation(
+          [],
+          txCallback,
+          ProtocolAction.setUsageAsCollateral,
+        ),
       },
     ];
   }

--- a/packages/contract-helpers/src/lendingPool-contract/lendingPool.test.ts
+++ b/packages/contract-helpers/src/lendingPool-contract/lendingPool.test.ts
@@ -1468,7 +1468,11 @@ describe('LendingPool', () => {
       const tx: transactionType = await txObj.tx();
       expect(tx.to).toEqual(LENDING_POOL);
       expect(tx.from).toEqual(user);
-      expect(tx.gasLimit).toEqual(BigNumber.from(1));
+      expect(tx.gasLimit).toEqual(
+        BigNumber.from(
+          gasLimitRecommendations[ProtocolAction.setUsageAsCollateral].limit,
+        ),
+      );
       expect(tx.value).toEqual(DEFAULT_NULL_VALUE_ON_TX);
 
       const decoded = utils.defaultAbiCoder.decode(
@@ -1482,7 +1486,9 @@ describe('LendingPool', () => {
       // gas price
       const gasPrice: GasType | null = await txObj.gas();
       expect(gasPrice).not.toBeNull();
-      expect(gasPrice?.gasLimit).toEqual('1');
+      expect(gasPrice?.gasLimit).toEqual(
+        gasLimitRecommendations[ProtocolAction.setUsageAsCollateral].limit,
+      );
       expect(gasPrice?.gasPrice).toEqual('1');
     });
     it('Expects the tx object passing all params with usage as collateral false', async () => {
@@ -1503,7 +1509,11 @@ describe('LendingPool', () => {
       const tx: transactionType = await txObj.tx();
       expect(tx.to).toEqual(LENDING_POOL);
       expect(tx.from).toEqual(user);
-      expect(tx.gasLimit).toEqual(BigNumber.from(1));
+      expect(tx.gasLimit).toEqual(
+        BigNumber.from(
+          gasLimitRecommendations[ProtocolAction.setUsageAsCollateral].limit,
+        ),
+      );
       expect(tx.value).toEqual(DEFAULT_NULL_VALUE_ON_TX);
 
       const decoded = utils.defaultAbiCoder.decode(
@@ -1517,7 +1527,9 @@ describe('LendingPool', () => {
       // gas price
       const gasPrice: GasType | null = await txObj.gas();
       expect(gasPrice).not.toBeNull();
-      expect(gasPrice?.gasLimit).toEqual('1');
+      expect(gasPrice?.gasLimit).toEqual(
+        gasLimitRecommendations[ProtocolAction.setUsageAsCollateral].limit,
+      );
       expect(gasPrice?.gasPrice).toEqual('1');
     });
     it('Expects to fail when lendingPoolAddress not provided', () => {

--- a/packages/contract-helpers/src/staking-contract/index.ts
+++ b/packages/contract-helpers/src/staking-contract/index.ts
@@ -4,6 +4,7 @@ import BaseService from '../commons/BaseService';
 import {
   eEthereumTxType,
   EthereumTransactionTypeExtended,
+  ProtocolAction,
   tEthereumAddress,
   transactionType,
 } from '../commons/types';
@@ -210,7 +211,6 @@ export class StakingService
       txs.push(approveTx);
     }
 
-    console.log(stakingContract);
     const txCallback: () => Promise<transactionType> = this.generateTxCallback({
       rawTxMethod: async () =>
         stakingContract.populateTransaction.stake(
@@ -218,12 +218,17 @@ export class StakingService
           convertedAmount,
         ),
       from: user,
+      action: ProtocolAction.stake,
     });
 
     txs.push({
       tx: txCallback,
       txType: eEthereumTxType.STAKE_ACTION,
-      gas: this.generateTxPriceEstimation(txs, txCallback),
+      gas: this.generateTxPriceEstimation(
+        txs,
+        txCallback,
+        ProtocolAction.stake,
+      ),
     });
 
     return txs;
@@ -311,13 +316,18 @@ export class StakingService
         stakingContract.populateTransaction.claimRewards(user, convertedAmount),
       from: user,
       gasSurplus: 20,
+      action: ProtocolAction.claimRewards,
     });
 
     return [
       {
         tx: txCallback,
         txType: eEthereumTxType.STAKE_ACTION,
-        gas: this.generateTxPriceEstimation([], txCallback),
+        gas: this.generateTxPriceEstimation(
+          [],
+          txCallback,
+          ProtocolAction.claimRewards,
+        ),
       },
     ];
   }

--- a/packages/contract-helpers/src/staking-contract/staking.test.ts
+++ b/packages/contract-helpers/src/staking-contract/staking.test.ts
@@ -300,7 +300,9 @@ describe('StakingService', () => {
       const tx: transactionType = await stakeTxObj[0].tx();
       expect(tx.to).toEqual(TOKEN_STAKING_ADDRESS);
       expect(tx.from).toEqual(user);
-      expect(tx.gasLimit).toEqual(BigNumber.from(1));
+      expect(tx.gasLimit).toEqual(
+        BigNumber.from(gasLimitRecommendations[ProtocolAction.stake].limit),
+      );
 
       const decoded = utils.defaultAbiCoder.decode(
         ['address', 'uint256'],
@@ -313,7 +315,9 @@ describe('StakingService', () => {
       // gas price
       const gasPrice: GasType | null = await stakeTxObj[0].gas();
       expect(gasPrice).not.toBeNull();
-      expect(gasPrice?.gasLimit).toEqual('1');
+      expect(gasPrice?.gasLimit).toEqual(
+        gasLimitRecommendations[ProtocolAction.stake].limit,
+      );
       expect(gasPrice?.gasPrice).toEqual('1');
     });
     it('Expects the tx object when all params passed and no onBehalfOf with approval needed', async () => {
@@ -352,7 +356,9 @@ describe('StakingService', () => {
       const tx: transactionType = await stakeTxObj[1].tx();
       expect(tx.to).toEqual(TOKEN_STAKING_ADDRESS);
       expect(tx.from).toEqual(user);
-      expect(tx.gasLimit).toEqual(BigNumber.from(1));
+      expect(tx.gasLimit).toEqual(
+        BigNumber.from(gasLimitRecommendations[ProtocolAction.stake].limit),
+      );
 
       const decoded = utils.defaultAbiCoder.decode(
         ['address', 'uint256'],
@@ -366,7 +372,7 @@ describe('StakingService', () => {
       const gasPrice: GasType | null = await stakeTxObj[1].gas();
       expect(gasPrice).not.toBeNull();
       expect(gasPrice?.gasLimit).toEqual(
-        gasLimitRecommendations[ProtocolAction.default].limit,
+        gasLimitRecommendations[ProtocolAction.stake].limit,
       );
       expect(gasPrice?.gasPrice).toEqual('1');
     });
@@ -600,7 +606,11 @@ describe('StakingService', () => {
       const tx: transactionType = await claimRewardsTxObj[0].tx();
       expect(tx.to).toEqual(TOKEN_STAKING_ADDRESS);
       expect(tx.from).toEqual(user);
-      expect(tx.gasLimit).toEqual(BigNumber.from(1));
+      expect(tx.gasLimit).toEqual(
+        BigNumber.from(
+          gasLimitRecommendations[ProtocolAction.claimRewards].limit,
+        ),
+      );
 
       const decoded = utils.defaultAbiCoder.decode(
         ['address', 'uint256'],
@@ -613,7 +623,9 @@ describe('StakingService', () => {
       // gas price
       const gasPrice: GasType | null = await claimRewardsTxObj[0].gas();
       expect(gasPrice).not.toBeNull();
-      expect(gasPrice?.gasLimit).toEqual('1');
+      expect(gasPrice?.gasLimit).toEqual(
+        gasLimitRecommendations[ProtocolAction.claimRewards].limit,
+      );
       expect(gasPrice?.gasPrice).toEqual('1');
     });
     it('Expects the tx object when all params passed with -1 amount', async () => {
@@ -628,7 +640,11 @@ describe('StakingService', () => {
       const tx: transactionType = await claimRewardsTxObj[0].tx();
       expect(tx.to).toEqual(TOKEN_STAKING_ADDRESS);
       expect(tx.from).toEqual(user);
-      expect(tx.gasLimit).toEqual(BigNumber.from(1));
+      expect(tx.gasLimit).toEqual(
+        BigNumber.from(
+          gasLimitRecommendations[ProtocolAction.claimRewards].limit,
+        ),
+      );
 
       const decoded = utils.defaultAbiCoder.decode(
         ['address', 'uint256'],
@@ -641,7 +657,9 @@ describe('StakingService', () => {
       // gas price
       const gasPrice: GasType | null = await claimRewardsTxObj[0].gas();
       expect(gasPrice).not.toBeNull();
-      expect(gasPrice?.gasLimit).toEqual('1');
+      expect(gasPrice?.gasLimit).toEqual(
+        gasLimitRecommendations[ProtocolAction.claimRewards].limit,
+      );
       expect(gasPrice?.gasPrice).toEqual('1');
     });
     it('Expects to fail when not initialized with TOKEN_STAKING_ADDRESS', async () => {


### PR DESCRIPTION
Added gas limit recommendations for `stake`, `claimRewards` and `setUsageAsCollateral` based on the average gas used in the most recent 400 txs plus a 15% buffer