### PR TITLE
feat: add Scroll Sepolia and Scroll chainIds

### DIFF
--- a/packages/contract-helpers/src/commons/types.ts
+++ b/packages/contract-helpers/src/commons/types.ts
@@ -34,6 +34,8 @@ export const ChainIdToNetwork: Record<number, string> = {
   1666700000: 'harmony_testnet',
   11155111: 'sepolia',
   534353: 'scroll_alpha',
+  534351: 'scroll_sepolia',
+  534352: 'scroll',
   1088: 'metis_andromeda',
 };
 
@@ -61,6 +63,8 @@ export enum ChainId {
   zkevm_testnet = 1402,
   sepolia = 11155111,
   scroll_alpha = 534353,
+  scroll_sepolia = 534351,
+  scroll = 534352,
   metis_andromeda = 1088,
 }
 export type ConstantAddressesByNetwork = Record<


### PR DESCRIPTION
Adds Scroll Sepolia and Scroll mainnet chainIds for use in Aave frontend.

Context: Follow-up after #528 -- Scroll is upgrading to a Sepolia testnet before mainnet launch.

