### PR TITLE
fix: include math-utils src files for sourcemaps

### DIFF
--- a/packages/math-utils/package.json
+++ b/packages/math-utils/package.json
@@ -22,6 +22,7 @@
   "module": "./dist/esm/index.js",
   "types": "./dist/esm/index.d.ts",
   "files": [
+    "src",
     "dist",
     "package.json",
     "package-lock.json",


### PR DESCRIPTION
Close #558 