### PR TITLE
doc: fix supply() README

### DIFF
--- a/README.md
+++ b/README.md
@@ -542,6 +542,7 @@ const supplyBundle: ActionBundle = await poolBundle.supplyBundle({
 });
 
 // Submit bundle components as shown in #bundle-methods section
+````
 
 </details>
 


### PR DESCRIPTION
Documentation for `supply()` was not visible. Fixed.