### PR TITLE
Fix #620 (numeric overflow in UiPoolDataProvider.getReservesHumanized

### DIFF
--- a/packages/contract-helpers/src/v3-UiPoolDataProvider-contract/index.ts
+++ b/packages/contract-helpers/src/v3-UiPoolDataProvider-contract/index.ts
@@ -184,7 +184,7 @@ export class UiPoolDataProvider implements UiPoolDataProviderInterface {
           accruedToTreasury: reserveRaw.accruedToTreasury.toString(),
           unbacked: reserveRaw.unbacked.toString(),
           isolationModeTotalDebt: reserveRaw.isolationModeTotalDebt.toString(),
-          debtCeilingDecimals: reserveRaw.debtCeilingDecimals.toNumber(),
+          debtCeilingDecimals: reserveRaw.debtCeilingDecimals.toString(),
           isSiloedBorrowing: reserveRaw.isSiloedBorrowing,
           flashLoanEnabled: reserveRaw.flashLoanEnabled,
           virtualAccActive,


### PR DESCRIPTION
Prevents numeric overflow by representing the number as string

Closes #620